### PR TITLE
2021 09 22 node 16

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [14.x, 15.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-buster-slim AS builder
+FROM node:16-buster-slim AS builder
 
 WORKDIR /build
 COPY . .
@@ -10,7 +10,7 @@ RUN npm run build
 WORKDIR /build/oracle-server-ui-proxy
 RUN npm i
 
-FROM node:12-buster-slim
+FROM node:16-buster-slim
 USER 1000
 WORKDIR /build
 COPY --from=builder /build .


### PR DESCRIPTION
Upgrades our node runtime to 16 in docker images and adds node 16 to CI. 

This PR also drops node 12 testing on CI.