### PR TITLE
Add workflow to start up docker container for oracle server

### DIFF
--- a/.github/workflows/oracle-server-rpc-tests.yml
+++ b/.github/workflows/oracle-server-rpc-tests.yml
@@ -1,0 +1,19 @@
+name: oracle-server-ts rpc tests
+on:
+  push:
+    branches: [master, main]
+    tags: ["*"]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - name: Pull latest oracle server docker image
+        run: docker pull bitcoinscala/bitcoin-s-oracle-server:latest
+      - name: 'Run oracle server docker image'
+        run: docker run -d -p 9998:9998 bitcoinscala/bitcoin-s-oracle-server:latest
+      # run typescript tests next

--- a/.github/workflows/oracle-server-rpc-tests.yml
+++ b/.github/workflows/oracle-server-rpc-tests.yml
@@ -1,8 +1,7 @@
 name: oracle-server-ts rpc tests
 on:
-  push:
-    branches: [master, main]
-    tags: ["*"]
+  pull_request:
+    branches: [ master ]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Testing this on CI, it should start a docker container running the latest CI image published for the oracle-server on dockerhub 

https://hub.docker.com/r/bitcoinscala/bitcoin-s-oracle-server

This should allow us to run automated tests everytime we merge things into master against our Scala backend. Hopefully this complements #14 