### PR TITLE
Add /tor endpoints to support tor-proxied service calls

### DIFF
--- a/oracle-server-ui-proxy/config.json
+++ b/oracle-server-ui-proxy/config.json
@@ -3,6 +3,8 @@
 	"stopOnError": false,
 	"useHTTPS": false,
 	"apiRoot": "/api/v0",
+	"torProxyRoot": "/tor",
+	"torProxyUrl": "socks5://127.0.0.1:9050",
 	"proxyRoot": "/proxy",
 	"oracleExplorerRoot": "/oracleexplorer",
 	"oracleServerUrl": "http://localhost:9998/",

--- a/oracle-server-ui-proxy/package-lock.json
+++ b/oracle-server-ui-proxy/package-lock.json
@@ -11,7 +11,8 @@
         "git-last-commit": "^1.0.1",
         "http-proxy-middleware": "^2.0.1",
         "node-fetch": "^2.6.1",
-        "request": "^2.88.2"
+        "request": "^2.88.2",
+        "socks-proxy-agent": "^6.1.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",
@@ -215,6 +216,38 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -1255,6 +1288,11 @@
       "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
       "dev": true
     },
+    "node_modules/ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -2060,6 +2098,62 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
+      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "dependencies": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz",
+      "integrity": "sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.1",
+        "socks": "^2.6.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -2639,6 +2733,29 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.1.tgz",
       "integrity": "sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -3452,6 +3569,11 @@
       "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
       "dev": true
     },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -4073,6 +4195,45 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
+    "socks": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
+      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.1.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz",
+      "integrity": "sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==",
+      "requires": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.1",
+        "socks": "^2.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "sshpk": {
       "version": "1.16.1",

--- a/oracle-server-ui-proxy/package.json
+++ b/oracle-server-ui-proxy/package.json
@@ -11,7 +11,8 @@
     "express": "^4.17.1",
     "http-proxy-middleware": "^2.0.1",
     "node-fetch": "^2.6.1",
-    "request": "^2.88.2"
+    "request": "^2.88.2",
+    "socks-proxy-agent": "^6.1.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/oracle-server-ui-proxy/server-config.ts
+++ b/oracle-server-ui-proxy/server-config.ts
@@ -4,6 +4,8 @@ export class ServerConfig {
 	stopOnError: boolean = false
 	useHTTPS: boolean = false
 	apiRoot: string   // prefix on local forwarding endpoint paths like '/api/v0'
+	torProxyRoot: string // prefix on local paths like '/tor'
+	torProxyUrl: string // like 'socks5://127.0.0.1:9050'
 	proxyRoot: string // prefix on local paths like '/proxy'
 	oracleExplorerRoot: string // prefix on local paths like '/oracleexplorer'
 	oracleServerUrl: string // oracle server endpoint like 'http://host:port/'

--- a/oracle-server-ui-proxy/server.ts
+++ b/oracle-server-ui-proxy/server.ts
@@ -163,10 +163,9 @@ createProxies()
 
 const DEFAULT_TOR_PROXY = Config.torProxyUrl
 const USE_TOR_PROXY = !!process.env.TOR_PROXY || !!DEFAULT_TOR_PROXY
-let agent = null
 if (USE_TOR_PROXY) {
   const torProxyUrl = process.env.TOR_PROXY || DEFAULT_TOR_PROXY
-  agent = new SocksProxyAgent(torProxyUrl)
+  const agent = new SocksProxyAgent(torProxyUrl)
   createProxies(agent)
 }
 

--- a/oracle-server-ui/src/app/app.module.ts
+++ b/oracle-server-ui/src/app/app.module.ts
@@ -17,8 +17,11 @@ import { LastResultDetailComponent } from './last-result-detail/last-result-deta
 import { ConfigurationComponent } from './configuration/configuration.component'
 import { SignMessageComponent } from './sign-message/sign-message.component'
 
-import { ConfirmationDialogComponent } from './dialog/confirmation/confirmation.component';
 import { AlertComponent } from './component/alert/alert.component'
+
+import { ConfirmationDialogComponent } from './dialog/confirmation/confirmation.component'
+import { ErrorDialogComponent } from './dialog/error/error.component'
+
 
 // AoT requires an exported function for factories
 export function createTranslateLoader(http: HttpClient) {
@@ -43,9 +46,11 @@ export function appInitializerFactory(translate: TranslateService) {
     MoreInfoComponent,
     LastResultDetailComponent,
     
-    ConfirmationDialogComponent,
     ConfigurationComponent,
     SignMessageComponent,
+
+    ConfirmationDialogComponent,
+    ErrorDialogComponent,
   ],
   imports: [
     BrowserModule,

--- a/oracle-server-ui/src/app/configuration/configuration.component.html
+++ b/oracle-server-ui/src/app/configuration/configuration.component.html
@@ -11,5 +11,10 @@
         <mat-option *ngFor="let o of ORACLE_EXPLORERS" [value]="o.value">{{ o.name }}</mat-option>
       </mat-select>
     </mat-form-field>
+    <div class="mat-form-field--checkbox">
+      <mat-label translate>configuration.useTor</mat-label>
+      <mat-checkbox [checked]="useTor" (change)="useTorChanged($event)"></mat-checkbox>
+      <app-more-info matSuffix tooltip="configuration.useTorTooltip"></app-more-info>
+    </div>
   </form>
 </section>

--- a/oracle-server-ui/src/app/configuration/configuration.component.html
+++ b/oracle-server-ui/src/app/configuration/configuration.component.html
@@ -17,4 +17,12 @@
       <app-more-info matSuffix tooltip="configuration.useTorTooltip"></app-more-info>
     </div>
   </form>
+
+  <div class="button-container">
+    <button mat-stroked-button (click)="onRefreshOracleData()">
+      <mat-icon>refresh</mat-icon>
+      <span class="button-label" translate>oracle.refreshData</span>
+    </button>
+  </div>
+
 </section>

--- a/oracle-server-ui/src/app/configuration/configuration.component.scss
+++ b/oracle-server-ui/src/app/configuration/configuration.component.scss
@@ -10,4 +10,15 @@
   .form-container > * {
     width: 100%;
   }
+
+  .button-container {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+
+    button {
+      span {
+        margin-left: 0.4rem;
+      }
+    }
+  }
 }

--- a/oracle-server-ui/src/app/configuration/configuration.component.ts
+++ b/oracle-server-ui/src/app/configuration/configuration.component.ts
@@ -1,6 +1,8 @@
 import { Component, EventEmitter, OnInit, Output } from '@angular/core'
+import { MatCheckboxChange } from '@angular/material/checkbox'
 
 import { OracleExplorerService, ORACLE_EXPLORERS } from '~service/oracle-explorer.service'
+import { TorService } from '~service/tor.service'
 
 
 @Component({
@@ -15,11 +17,13 @@ export class ConfigurationComponent implements OnInit {
   public ORACLE_EXPLORERS = ORACLE_EXPLORERS
 
   oracleExplorer: string // 'test', 'prod'
+  useTor: boolean
 
-  constructor(private oracleExplorerService: OracleExplorerService) { }
+  constructor(private oracleExplorerService: OracleExplorerService, private torService: TorService) { }
 
   ngOnInit(): void {
     this.oracleExplorer = this.oracleExplorerService.oracleExplorer.value.value
+    this.useTor = this.torService.useTor
   }
 
   onClose() {
@@ -33,6 +37,11 @@ export class ConfigurationComponent implements OnInit {
     if (oracleExplorer) {
       this.oracleExplorerService.setOracleExplorer(oracleExplorer)
     }
+  }
+
+  useTorChanged(change: MatCheckboxChange) {
+    console.debug('useTorChanged()', change)
+    this.torService.useTor = change.checked
   }
 
 }

--- a/oracle-server-ui/src/app/configuration/configuration.component.ts
+++ b/oracle-server-ui/src/app/configuration/configuration.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, OnInit, Output } from '@angular/core'
 import { MatCheckboxChange } from '@angular/material/checkbox'
 
 import { OracleExplorerService, ORACLE_EXPLORERS } from '~service/oracle-explorer.service'
+import { OracleStateService } from '~service/oracle-state.service'
 import { TorService } from '~service/tor.service'
 
 
@@ -19,7 +20,7 @@ export class ConfigurationComponent implements OnInit {
   oracleExplorer: string // 'test', 'prod'
   useTor: boolean
 
-  constructor(private oracleExplorerService: OracleExplorerService, private torService: TorService) { }
+  constructor(private oracleExplorerService: OracleExplorerService, private torService: TorService, private oracleState: OracleStateService) { }
 
   ngOnInit(): void {
     this.oracleExplorer = this.oracleExplorerService.oracleExplorer.value.value
@@ -42,6 +43,13 @@ export class ConfigurationComponent implements OnInit {
   useTorChanged(change: MatCheckboxChange) {
     console.debug('useTorChanged()', change)
     this.torService.useTor = change.checked
+  }
+
+  // Refresh oracleExplorer / Blockstream data that may not have loaded over tor previously
+  onRefreshOracleData() {
+    console.debug('onRefreshOracleData()')
+    this.oracleState.getOracleName()
+    this.oracleState.getStakingBalance()
   }
 
 }

--- a/oracle-server-ui/src/app/dialog/error/error.component.html
+++ b/oracle-server-ui/src/app/dialog/error/error.component.html
@@ -1,0 +1,5 @@
+<h2 mat-dialog-title>{{ data.title | translate }}</h2>
+<mat-dialog-content [translate]="data.content" [translateParams]="data.params"></mat-dialog-content>
+<mat-dialog-actions>
+  <button mat-button mat-dialog-close>{{ 'action.ok' | translate }}</button>
+</mat-dialog-actions>

--- a/oracle-server-ui/src/app/dialog/error/error.component.spec.ts
+++ b/oracle-server-ui/src/app/dialog/error/error.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ErrorDialogComponent } from './error.component';
+
+describe('ErrorDialogComponent', () => {
+  let component: ErrorDialogComponent;
+  let fixture: ComponentFixture<ErrorDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ErrorDialogComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ErrorDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/oracle-server-ui/src/app/dialog/error/error.component.ts
+++ b/oracle-server-ui/src/app/dialog/error/error.component.ts
@@ -1,0 +1,20 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+
+export interface ErrorDialogContent {
+  title: string
+  content: string
+  params: any // { key: value }
+  // action: string
+}
+
+@Component({
+  selector: 'error-dialog',
+  templateUrl: './error.component.html',
+  styleUrls: ['./error.component.scss']
+})
+export class ErrorDialogComponent {
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: ErrorDialogContent) { }
+}

--- a/oracle-server-ui/src/app/new-event/new-event.component.scss
+++ b/oracle-server-ui/src/app/new-event/new-event.component.scss
@@ -22,13 +22,4 @@
     padding-right: 1rem;
   }
   
-  // Center checkbox in pseudo-mat-form-field
-  .mat-form-field--checkbox {
-    display: flex;
-    flex-direction: row;
-
-    mat-checkbox {
-      margin: auto;
-    }
-  }
 }

--- a/oracle-server-ui/src/app/new-event/new-event.component.ts
+++ b/oracle-server-ui/src/app/new-event/new-event.component.ts
@@ -7,10 +7,12 @@ import { AlertType } from '~app/component/alert/alert.component'
 import { MessageService } from '~service/message.service'
 import { OracleExplorerService } from '~service/oracle-explorer.service'
 import { OracleStateService } from '~service/oracle-state.service'
+
 import { EventType } from '~type/client-types'
 import { OracleServerMessage } from '~type/oracle-server-message'
 import { MessageType } from '~type/oracle-server-types'
-import { getMessageBody } from '~util/message-util'
+
+import { getMessageBody } from '~util/oracle-server-util'
 
 
 /** Validators */

--- a/oracle-server-ui/src/app/oracle/oracle.component.html
+++ b/oracle-server-ui/src/app/oracle/oracle.component.html
@@ -10,15 +10,15 @@
         
       <mat-form-field>
         <mat-label translate>oracle.publicKey</mat-label>
-        <input matInput name="publicKey" type="text" [(ngModel)]="publicKey" readonly="true">
+        <input matInput name="publicKey" type="text" [(ngModel)]="oracleState.publicKey" readonly="true">
       </mat-form-field>
       <mat-form-field>
         <mat-label translate>oracle.stakingAddress</mat-label>
-        <input matInput name="stakingAddress" type="text" [(ngModel)]="stakingAddress" readonly="true">
+        <input matInput name="stakingAddress" type="text" [(ngModel)]="oracleState.stakingAddress" readonly="true">
       </mat-form-field>
       <mat-form-field>
         <mat-label translate>oracle.stakedAmount</mat-label>
-        <input matInput name="stakedAmount" type="text" [(ngModel)]="stakedAmount" readonly="true">
+        <input matInput name="stakedAmount" type="text" [(ngModel)]="oracleState.stakedAmount" readonly="true">
       </mat-form-field>
     </form>
   </div>

--- a/oracle-server-ui/src/app/oracle/oracle.component.html
+++ b/oracle-server-ui/src/app/oracle/oracle.component.html
@@ -24,21 +24,9 @@
   </div>
 
   <div class="debug-buttons" [hidden]="hideRawButtons">
-
-    <h4 class="debug-label" translate>oracle.heading</h4>
-    <nav class="debug-button-group">
-      <button type="button" (click)="onOracleHeartbeat()" translate>oracleOperations.heartbeat</button>
-      <!-- <button type="button" (click)="getAllEvents()" translate>oracleOperations.getAllEvents</button> -->
-  
-      <button type="button" (click)="onGetPublicKey()" translate>oracleOperations.getpublickey</button>
-      <button type="button" (click)="onGetStakingAddress()" translate>oracleOperations.getstakingaddress</button>
-      <!-- <button type="button" (click)="onListEvents()" translate>oracleOperations.listevents</button> -->
-    </nav>
-  
     <h4 class="debug-label" translate>oracleExplorer.heading</h4>
     <nav class="debug-button-group">
       <button type="button" (click)="listAnnouncements()" translate>oracleExplorerOperations.listAnnouncements</button>
-      <!-- <button type="button" (click)="getLocalEventAnnouncements()" translate>oracleExplorerOperations.getLocalEventAnnouncements</button> -->
     </nav>
   </div>
 

--- a/oracle-server-ui/src/app/oracle/oracle.component.html
+++ b/oracle-server-ui/src/app/oracle/oracle.component.html
@@ -47,7 +47,7 @@
       <mat-icon>add_circle_outline</mat-icon>
       <span class="button-label" translate>createEvent.heading</span>
     </button>
-    <button mat-stroked-button (click)="oracleState.getAllEvents().subscribe()">
+    <button mat-stroked-button (click)="onRefreshEvents()">
       <mat-icon>refresh</mat-icon>
       <span class="button-label" translate>oracleOperations.refreshEvents</span>
     </button>
@@ -81,7 +81,7 @@
             <ng-container *ngSwitchCase="undefined"></ng-container>
             <ng-container *ngSwitchCase="null">
               <button mat-icon-button
-                matTooltip="{{'eventTable.broadcastAnnouncement' | translate}}" matTooltipPosition="right"
+                matTooltip="{{'eventTable.broadcastAnnouncement' | translate}}"
                 (click)="onAnnouncementClick(event); $event.stopPropagation()"
               ><mat-icon class="material-icons-outlined">announcement</mat-icon>
               </button>
@@ -89,8 +89,7 @@
             <ng-container *ngSwitchDefault>
               <button mat-icon-button (click)="onAnnouncementLinkClick(event); $event.stopPropagation()">
                 <mat-icon class="material-icons-outlined icon-inactive"
-                  matTooltip="{{ 'eventTable.viewOnOracleExplorer' | translate }}"
-                  matTooltipPosition="right">link</mat-icon>
+                  matTooltip="{{ 'eventTable.viewOnOracleExplorer' | translate }}">link</mat-icon>
               </button>
             </ng-container>
           </ng-container>
@@ -109,8 +108,12 @@
       <ng-container matColumnDef="signedOutcome">
         <th mat-header-cell *matHeaderCellDef translate="outcome"></th>
         <td mat-cell *matCellDef="let event">
-          <ng-container *ngIf="event.signedOutcome !== null">
+          <div *ngIf="event.signedOutcome !== null" class="signedOutcome-container">
+            <span class="outcome-label">{{ event.signedOutcome }}</span>
 
+            <ng-container *ngIf="oracleName && oracleState.announcements.value[event.eventName] === undefined">
+              <mat-spinner class="spinner" diameter="20"></mat-spinner>
+            </ng-container>
             <ng-container *ngIf="oracleName && oracleState.announcements.value[event.eventName]">
               <ng-container *ngIf="oracleState.announcements.value[event.eventName]?.outcome; else announceOutcome">
                 <!-- TODO : Button only here to fix spacing, need to find magic -->
@@ -124,9 +127,7 @@
                 </button>
               </ng-template>
             </ng-container>
-
-            <span class="outcome-label">{{ event.signedOutcome }}</span>
-          </ng-container>
+          </div>
         </td>
       </ng-container>
 
@@ -136,12 +137,14 @@
     </table>
   </div>
 
+  <mat-spinner *ngIf="loading" class="spinner" diameter="200"></mat-spinner>
+
   <div *ngIf="buildConfig" class="footer">
-    <div>
+    <div class="footer-section">
       <span class="label" translate>server</span>
       <span class="server-version">{{ serverVersion }}</span>
     </div>
-    <div>
+    <div class="footer-section">
       <span class="label" translate>ui</span>
       <span class="version">{{ buildConfig.shortHash }}</span>
       <span class="date">{{ buildConfig.dateString }}</span>

--- a/oracle-server-ui/src/app/oracle/oracle.component.scss
+++ b/oracle-server-ui/src/app/oracle/oracle.component.scss
@@ -158,6 +158,8 @@
     display: flex;
     font-size: smaller;
     color: #8c959f;
+    
+    margin-bottom: 0.25rem;
 
     .label {
       margin-right: 0.25rem;

--- a/oracle-server-ui/src/app/oracle/oracle.component.scss
+++ b/oracle-server-ui/src/app/oracle/oracle.component.scss
@@ -118,6 +118,19 @@
         max-width: 200px;
       }
 
+      .mat-column-signedOutcome {
+        .signedOutcome-container {
+          display: flex;
+          align-items: center;
+
+          max-height: 45px; // spinner blows out height otherwise
+
+          .spinner {
+            margin-left: 0.5rem;
+          }
+        }
+      }
+
       .icon-inactive {
         opacity: 0.25;
       }
@@ -134,6 +147,11 @@
         }
       }
     }
+  }
+
+  .spinner {
+    margin-top: 3rem;
+    margin-bottom: 3rem;
   }
   
   .footer {

--- a/oracle-server-ui/src/app/oracle/oracle.component.ts
+++ b/oracle-server-ui/src/app/oracle/oracle.component.ts
@@ -10,10 +10,10 @@ import { MessageService } from '~service/message.service'
 import { OracleExplorerService } from '~service/oracle-explorer.service'
 import { OracleStateService } from '~service/oracle-state.service'
 
-import { MessageType, OracleEvent } from '~type/oracle-server-types'
+import { OracleEvent } from '~type/oracle-server-types'
 import { BuildConfig } from '~type/proxy-server-types'
 
-import { formatOutcomes, getMessageBody } from '~util/oracle-server-util'
+import { formatOutcomes } from '~util/oracle-server-util'
 import { KrystalBullImages } from '~util/ui-util'
 
 
@@ -43,9 +43,6 @@ export class OracleComponent implements OnInit, AfterViewInit {
   // Oracle Info
   oracleName = ''
   oracleNameReadOnly = true // don't allow editing until checking for a name
-  publicKey = ''
-  stakingAddress = ''
-  stakedAmount = ''
 
   serverVersion = ''
   buildConfig: BuildConfig
@@ -82,8 +79,6 @@ export class OracleComponent implements OnInit, AfterViewInit {
         this.buildConfig = result
       }
     })
-    this.onGetPublicKey()
-    this.onGetStakingAddress()
     this.oracleState.getAllEvents().subscribe(_ => {
       console.debug('initial getAllEvents() complete')
     })
@@ -109,48 +104,12 @@ export class OracleComponent implements OnInit, AfterViewInit {
     })
   }
 
-  private getOracleName(publicKey: string) {
-    this.oracleExplorerService.getLocalOracleName(publicKey).subscribe(result => {
-      console.debug('getOracleName()', result)
-    })
-  }
-
-  /** Blockstream handlers */
-
-  getStakingBalance(address: string) {
-    this.blockstreamService.getBalance(address).subscribe(result => {
-      this.stakedAmount = this.blockstreamService.balanceFromGetBalance(result).toString()
-    })
-  }
-
   /** Debug button handlers */
 
   onOracleHeartbeat() {
     console.debug('onOracleHeartbeateartbeat')
     this.messageService.oracleHeartbeat().subscribe(result => {
       console.debug('oracle heartbeat:', result)
-    })
-  }
-
-  onGetPublicKey() {
-    console.debug('onGetPublicKey')
-    this.messageService.sendMessage(getMessageBody(MessageType.getpublickey)).subscribe(result => {
-      if (result.result) {
-        this.publicKey = result.result
-        if (!this.oracleName) {
-          this.getOracleName(this.publicKey)
-        }
-      }
-    })
-  }
-
-  onGetStakingAddress() {
-    console.debug('onGetStakingAddress')
-    this.messageService.sendMessage(getMessageBody(MessageType.getstakingaddress)).subscribe(result => {
-      if (result.result) {
-        this.stakingAddress = result.result
-        this.getStakingBalance(this.stakingAddress)
-      }
     })
   }
 

--- a/oracle-server-ui/src/app/oracle/oracle.component.ts
+++ b/oracle-server-ui/src/app/oracle/oracle.component.ts
@@ -2,17 +2,18 @@ import { AfterViewInit, Component, EventEmitter, OnInit, Output, ViewChild } fro
 import { MatDialog } from '@angular/material/dialog'
 import { MatSort } from '@angular/material/sort'
 import { MatTable, MatTableDataSource } from '@angular/material/table'
-import { forkJoin } from 'rxjs'
 
 import { ConfirmationDialogComponent } from '~app/dialog/confirmation/confirmation.component'
+
 import { BlockstreamService } from '~service/blockstream-service'
 import { MessageService } from '~service/message.service'
 import { OracleExplorerService } from '~service/oracle-explorer.service'
 import { OracleStateService } from '~service/oracle-state.service'
-import { OracleAnnouncementsResponse } from '~type/oracle-explorer-types'
+
 import { MessageType, OracleEvent } from '~type/oracle-server-types'
 import { BuildConfig } from '~type/proxy-server-types'
-import { getMessageBody } from '~util/message-util'
+
+import { formatOutcomes, getMessageBody } from '~util/oracle-server-util'
 import { KrystalBullImages } from '~util/ui-util'
 
 
@@ -29,6 +30,7 @@ export class OracleComponent implements OnInit, AfterViewInit {
   @Output() showSignMessage: EventEmitter<void> = new EventEmitter();
 
   public KrystalBullImages = KrystalBullImages
+  public formatOutcomes = formatOutcomes
 
   hideRawButtons = true
 
@@ -214,24 +216,6 @@ export class OracleComponent implements OnInit, AfterViewInit {
   onShowDebug() {
     console.debug('onShowDebug()')
     this.hideRawButtons = !this.hideRawButtons
-  }
-
-  formatOutcomes(outcomes: [any]): string {
-    if (outcomes && outcomes.length > 0) {
-      const head = outcomes[0]
-      if (Array.isArray(head) && head.length === 2) {
-        // numeric outcomes
-        const signed = head[0] === '+' && head[1] === '-'
-        const exp = signed ? outcomes.length - 1 : outcomes.length
-        const outcome = (2 ** exp) - 1
-        return signed ? '-' + outcome + '..' + outcome : '0..' + outcome
-      } else {
-        // enum and all other outcomes
-        return '' + outcomes
-      }
-    } else {
-      return ''
-    }
   }
 
   onRowClick(event: OracleEvent) {

--- a/oracle-server-ui/src/app/shared/modules/material/material.module.ts
+++ b/oracle-server-ui/src/app/shared/modules/material/material.module.ts
@@ -10,6 +10,7 @@ import { MatFormFieldModule } from '@angular/material/form-field'
 import { MatIconModule } from '@angular/material/icon'
 import { MatInputModule } from '@angular/material/input'
 import { MatNativeDateModule, MatOptionModule } from '@angular/material/core'
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
 import { MatRadioModule } from '@angular/material/radio'
 import { MatSelectModule } from '@angular/material/select'
 import { MatSidenavModule } from '@angular/material/sidenav'
@@ -29,6 +30,7 @@ const materialModules = [
   MatInputModule,
   MatNativeDateModule,
   MatOptionModule,
+  MatProgressSpinnerModule,
   MatSelectModule,
   MatSidenavModule,
   MatSnackBarModule,

--- a/oracle-server-ui/src/app/sign-message/sign-message.component.ts
+++ b/oracle-server-ui/src/app/sign-message/sign-message.component.ts
@@ -1,8 +1,10 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, OnInit, Output } from '@angular/core'
 
-import { MessageService } from '~service/message.service';
-import { MessageType } from '~type/oracle-server-types';
-import { getMessageBody } from '~util/message-util';
+import { MessageService } from '~service/message.service'
+
+import { MessageType } from '~type/oracle-server-types'
+
+import { getMessageBody } from '~util/oracle-server-util'
 
 
 @Component({

--- a/oracle-server-ui/src/assets/i18n/en.json
+++ b/oracle-server-ui/src/assets/i18n/en.json
@@ -47,7 +47,8 @@
     "name": "Oracle Name",
     "publicKey": "Public Key",
     "stakingAddress": "Staking Address",
-    "stakedAmount": "Staked Amount"
+    "stakedAmount": "Staked Amount",
+    "refreshData": "Refresh Local Oracle Data"
   },
 
   "oracleExplorerOperations": {
@@ -182,7 +183,9 @@
     "cancel": "Cancel",
     "dismiss": "Dismiss",
     "sign": "Sign",
-    "ok": "Ok"
+    "ok": "Ok",
+    "yes": "Yes",
+    "no": "No"
   }
 
 }

--- a/oracle-server-ui/src/assets/i18n/en.json
+++ b/oracle-server-ui/src/assets/i18n/en.json
@@ -17,6 +17,8 @@
   "server": "Server",
   "ui": "UI",
 
+  "error": "Error",
+
   "oracleOperations": {
     "getpublickey": "Get Public Key",
     "getstakingaddress": "Get Staking Address",
@@ -76,10 +78,27 @@
   },
 
   "dialog": {
+    "sendMessageError": {
+      "title": "Error sending message to OracleServer"
+    },
+    "oracleExplorerError": {
+      "title": "Error communicating to Oracle Explorer"
+    },
+    "blockstreamError": {
+      "title": "Error communicating to Blockstream"
+    },
     "confirmOracleName": {
       "title": "Confirm Oracle Name",
       "content": "Are you sure you want to set your Oracle Name to '{{oracleName}}'? Once used it cannot be changed.",
       "action": "Set Oracle Name"
+    },
+    "signedBelowMinimum": {
+      "title": "Signed message below minimum",
+      "content": "You entered {{input}}, which is below the minimum value. {{min}} was signed."
+    },
+    "signedAboveMaximum": {
+      "title": "Signed message above maximum",
+      "content": "You entered {{input}}, which is above the maximum value. {{max}} was signed."
     }
   },
 
@@ -162,7 +181,8 @@
   "action": {
     "cancel": "Cancel",
     "dismiss": "Dismiss",
-    "sign": "Sign"
+    "sign": "Sign",
+    "ok": "Ok"
   }
 
 }

--- a/oracle-server-ui/src/assets/i18n/en.json
+++ b/oracle-server-ui/src/assets/i18n/en.json
@@ -63,7 +63,9 @@
   },
 
   "configuration": {
-    "heading": "Configuration"
+    "heading": "Configuration",
+    "useTor": "Use Tor",
+    "useTorTooltip": "Use Tor network for external interactions"
   },
   
   "oracleExplorer": {

--- a/oracle-server-ui/src/environments/environment.prod.ts
+++ b/oracle-server-ui/src/environments/environment.prod.ts
@@ -1,6 +1,7 @@
 export const environment = {
   production: true,
   oracleServerApi: '/api/v0',
+  torApi: '/tor',
   oracleExplorerApi: '/oracleexplorer',
   blockstreamApi: '/blockstream',
   proxyApi: '',

--- a/oracle-server-ui/src/environments/environment.ts
+++ b/oracle-server-ui/src/environments/environment.ts
@@ -5,6 +5,7 @@
 export const environment = {
   production: false,
   oracleServerApi: '/api/v0',
+  torApi: '/tor',
   oracleExplorerApi: '/oracleexplorer',
   blockstreamApi: '/blockstream',
   proxyApi: '',

--- a/oracle-server-ui/src/service/blockstream-service.ts
+++ b/oracle-server-ui/src/service/blockstream-service.ts
@@ -4,14 +4,17 @@ import { Injectable } from '@angular/core'
 import { environment } from '~environments'
 
 import { AddressResponse } from '~type/blockstream-types'
+import { TorService } from './tor.service'
 
 
 @Injectable({ providedIn: 'root' })
 export class BlockstreamService {
 
-  private url = environment.blockstreamApi // if we want to change at runtime, will need host-override header like Oracle Explorer
+  private get url() {
+    return (this.torService.useTor ? environment.torApi : '') + environment.blockstreamApi
+  }
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private torService: TorService) {}
 
   /** Helper functions */
 

--- a/oracle-server-ui/src/service/blockstream-service.ts
+++ b/oracle-server-ui/src/service/blockstream-service.ts
@@ -1,9 +1,15 @@
 import { HttpClient } from '@angular/common/http'
 import { Injectable } from '@angular/core'
+import { MatDialog } from '@angular/material/dialog'
+import { Observable } from 'rxjs'
+import { catchError } from 'rxjs/operators'
 
 import { environment } from '~environments'
 
+import { ErrorDialogComponent } from '~app/dialog/error/error.component'
+
 import { AddressResponse } from '~type/blockstream-types'
+
 import { TorService } from './tor.service'
 
 
@@ -14,7 +20,20 @@ export class BlockstreamService {
     return (this.torService.useTor ? environment.torApi : '') + environment.blockstreamApi
   }
 
-  constructor(private http: HttpClient, private torService: TorService) {}
+  constructor(private http: HttpClient, private torService: TorService, private dialog: MatDialog) {}
+
+  private errorHandler(error: any, caught: Observable<unknown>) {
+    console.error('Blockstream errorHandler')
+    let message = error?.message
+    const dialog = this.dialog.open(ErrorDialogComponent, {
+      data: {
+        title: 'dialog.blockstreamError.title',
+        content: message,
+      }
+    })
+    throw(Error('Blockstream error ' + error))
+    return new Observable<any>() // required for type checking...
+  }
 
   /** Helper functions */
 
@@ -29,5 +48,6 @@ export class BlockstreamService {
 
   getBalance(address: string) {
     return this.http.get<AddressResponse>(this.url + `/address/${address}`)
+      .pipe(catchError(this.errorHandler.bind(this)))
   }
 }

--- a/oracle-server-ui/src/service/blockstream-service.ts
+++ b/oracle-server-ui/src/service/blockstream-service.ts
@@ -9,6 +9,7 @@ import { environment } from '~environments'
 import { ErrorDialogComponent } from '~app/dialog/error/error.component'
 
 import { AddressResponse } from '~type/blockstream-types'
+import { getProxyErrorHandler } from '~type/proxy-server-types'
 
 import { TorService } from './tor.service'
 
@@ -22,18 +23,14 @@ export class BlockstreamService {
 
   constructor(private http: HttpClient, private torService: TorService, private dialog: MatDialog) {}
 
-  private errorHandler(error: any, caught: Observable<unknown>) {
-    console.error('Blockstream errorHandler')
-    let message = error?.message
+  private errorHandler = getProxyErrorHandler('blockstream', (message: string) => {
     const dialog = this.dialog.open(ErrorDialogComponent, {
       data: {
         title: 'dialog.blockstreamError.title',
         content: message,
       }
     })
-    throw(Error('Blockstream error ' + error))
-    return new Observable<any>() // required for type checking...
-  }
+  }).bind(this)
 
   /** Helper functions */
 
@@ -47,7 +44,8 @@ export class BlockstreamService {
   /** API Calls */
 
   getBalance(address: string) {
+    console.debug('getBalance()')
     return this.http.get<AddressResponse>(this.url + `/address/${address}`)
-      .pipe(catchError(this.errorHandler.bind(this)))
+      .pipe(catchError(this.errorHandler))
   }
 }

--- a/oracle-server-ui/src/service/message.service.ts
+++ b/oracle-server-ui/src/service/message.service.ts
@@ -1,10 +1,13 @@
 import { HttpClient } from '@angular/common/http'
 import { Injectable } from '@angular/core'
+import { MatDialog } from '@angular/material/dialog'
 import { TranslateService } from '@ngx-translate/core'
 import { Observable } from 'rxjs'
-import { tap } from 'rxjs/operators'
+import { catchError, tap } from 'rxjs/operators'
 
 import { environment } from 'src/environments/environment'
+
+import { ErrorDialogComponent } from '~app/dialog/error/error.component'
 
 import { OracleServerMessage } from '~type/oracle-server-message'
 import { MessageType, OracleResponse, ServerVersion } from '~type/oracle-server-types'
@@ -20,7 +23,7 @@ export class MessageService {
   lastMessageType: MessageType|undefined = undefined
   lastMessageResults: string|undefined = undefined
 
-  constructor(private http: HttpClient, private translate: TranslateService) { }
+  constructor(private http: HttpClient, private translate: TranslateService, private dialog: MatDialog) { }
 
   /** Serializes a OracleServerMessage for sending to oracleServer */
   sendMessage(m: OracleServerMessage) {
@@ -44,7 +47,18 @@ export class MessageService {
 
   private sendServerMessage(message: OracleServerMessage) {
     const url = environment.oracleServerApi
-    return this.http.post<OracleResponse<any>>(url, message)
+    return this.http.post<OracleResponse<any>>(url, message).pipe(catchError((error: any, caught: Observable<unknown>) => {
+      console.error('sendMessage error', error)
+      let message = error?.error?.error
+      const dialog = this.dialog.open(ErrorDialogComponent, {
+        data: {
+          title: 'dialog.sendMessageError.title',
+          content: message,
+        }
+      })
+      throw(Error('sendMessage error' + error))
+      return new Observable<any>() // required for type checking...
+    }))
   }
 
   // Proxy server calls

--- a/oracle-server-ui/src/service/message.service.ts
+++ b/oracle-server-ui/src/service/message.service.ts
@@ -12,7 +12,8 @@ import { ErrorDialogComponent } from '~app/dialog/error/error.component'
 import { OracleServerMessage } from '~type/oracle-server-message'
 import { MessageType, OracleResponse, ServerVersion } from '~type/oracle-server-types'
 import { BuildConfig, SuccessType } from '~type/proxy-server-types'
-import { getMessageBody } from '~util/message-util'
+
+import { getMessageBody } from '~util/oracle-server-util'
 
 
 /** Service that communicates with underlying oracleServer instance through oracle-server-ui-proxy */

--- a/oracle-server-ui/src/service/oracle-explorer.service.ts
+++ b/oracle-server-ui/src/service/oracle-explorer.service.ts
@@ -10,6 +10,7 @@ import { ErrorDialogComponent } from '~app/dialog/error/error.component'
 
 import { OracleAnnouncementsResponse, OracleNameResponse } from '~type/oracle-explorer-types'
 import { OracleEvent } from '~type/oracle-server-types'
+import { getProxyErrorHandler } from '~type/proxy-server-types'
 
 import { TorService } from './tor.service'
 
@@ -56,18 +57,14 @@ export class OracleExplorerService {
     return { headers }
   }
 
-  private errorHandler(error: any, caught: Observable<unknown>) {
-    console.error('OracleExplorer errorHandler')
-    let message = error?.message
+  private errorHandler = getProxyErrorHandler('oracleExplorer', (message: string) => {
     const dialog = this.dialog.open(ErrorDialogComponent, {
       data: {
         title: 'dialog.oracleExplorerError.title',
         content: message,
       }
     })
-    throw(Error('OracleExplorer error ' + error))
-    return new Observable<any>() // required for type checking...
-  }
+  }).bind(this)
 
   /**
    * @see https://gist.github.com/Christewart/a9e55d9ba582ac9a5ceffa96db9d7e1f#list-all-events
@@ -75,7 +72,7 @@ export class OracleExplorerService {
    */
   listAnnouncements() {
     return this.http.get<OracleAnnouncementsResponse[]>(this.url + '/announcements', 
-      this.getHeaders()).pipe(catchError(this.errorHandler.bind(this)))
+      this.getHeaders()).pipe(catchError(this.errorHandler))
   }
 
   /**
@@ -84,7 +81,7 @@ export class OracleExplorerService {
    */
   getAnnouncement(announcementHash: string) {
     return this.http.get<OracleAnnouncementsResponse>(this.url + `/announcements/${announcementHash}`,
-      this.getHeaders()).pipe(catchError(this.errorHandler.bind(this)))
+      this.getHeaders()).pipe(catchError(this.errorHandler))
   }
 
   /**
@@ -105,7 +102,7 @@ export class OracleExplorerService {
     // TODO : Could allow user to enter URI
     
     return this.http.post<string>(this.url + '/announcements', body, this.getHeaders())
-      .pipe(catchError(this.errorHandler.bind(this)))
+      .pipe(catchError(this.errorHandler))
   }
 
   /**
@@ -122,12 +119,12 @@ export class OracleExplorerService {
     const body = new HttpParams()
       .set('attestations', event.attestations)
     return this.http.post<OracleNameResponse>(this.url + `/announcements/${event.announcementTLVsha256}/attestations`, body, this.getHeaders())
-      .pipe(catchError(this.errorHandler.bind(this)))
+      .pipe(catchError(this.errorHandler))
   }
 
   getOracleName(pubkey: string) {
     return this.http.get<OracleNameResponse>(this.url + `/oracle/${pubkey}`)
-      .pipe(catchError(this.errorHandler.bind(this)))
+      .pipe(catchError(this.errorHandler))
   }
 
   getLocalOracleName(pubkey: string) {

--- a/oracle-server-ui/src/service/oracle-explorer.service.ts
+++ b/oracle-server-ui/src/service/oracle-explorer.service.ts
@@ -7,6 +7,7 @@ import { environment } from '~environments'
 
 import { OracleAnnouncementsResponse, OracleNameResponse } from '~type/oracle-explorer-types'
 import { OracleEvent } from '~type/oracle-server-types'
+import { TorService } from './tor.service'
 
 
 // Host replacement header for proxy
@@ -26,7 +27,9 @@ const DEFAULT_ORACLE_EXPLORER_VALUE = 'test'
 @Injectable({ providedIn: 'root' })
 export class OracleExplorerService {
 
-  private url = environment.oracleExplorerApi
+  private get url() {
+    return (this.torService.useTor ? environment.torApi : '') + environment.oracleExplorerApi
+  }
 
   readonly oracleName: BehaviorSubject<string> = new BehaviorSubject('')
   readonly serverOracleName: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false)
@@ -37,7 +40,7 @@ export class OracleExplorerService {
     localStorage.setItem(ORACLE_EXPLORER_VALUE_KEY, oe.value)
   }
   
-  constructor(private http: HttpClient) {
+  constructor(private http: HttpClient, private torService: TorService) {
     const oracleValue = localStorage.getItem(ORACLE_EXPLORER_VALUE_KEY) || DEFAULT_ORACLE_EXPLORER_VALUE
     const oracle = ORACLE_EXPLORERS.find(o => o.value === oracleValue)
     this.oracleExplorer = new BehaviorSubject(oracle ? oracle : ORACLE_EXPLORERS[0])

--- a/oracle-server-ui/src/service/oracle-state.service.ts
+++ b/oracle-server-ui/src/service/oracle-state.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnInit } from '@angular/core'
-import { BehaviorSubject, forkJoin } from 'rxjs'
+import { BehaviorSubject, forkJoin, of } from 'rxjs'
 import { tap } from 'rxjs/operators'
 
 import { MessageService } from './message.service'
@@ -69,10 +69,10 @@ export class OracleStateService {
 
   private getLocalEventAnnouncements() {
     console.debug('getLocalEventAnnouncements()', this.flatEvents)
-
     this.announcements.next({})
     // Have seen these 403 against the Production Oracle Server over Tor
-    const obs = forkJoin(this.flatEvents.value.map(e => this.getAnnouncement(e)))
+    const obs = forkJoin(this.flatEvents.value.map(e => this.announcements.value[e.eventName] ? 
+      of(this.announcements.value[e.eventName]) : this.getAnnouncement(e)))
     return obs
   }
 

--- a/oracle-server-ui/src/service/oracle-state.service.ts
+++ b/oracle-server-ui/src/service/oracle-state.service.ts
@@ -2,11 +2,14 @@ import { Injectable, OnInit } from '@angular/core'
 import { BehaviorSubject, forkJoin, of } from 'rxjs'
 import { tap } from 'rxjs/operators'
 
-import { MessageService } from './message.service'
-import { OracleExplorerService } from './oracle-explorer.service'
 import { MessageType, OracleEvent } from '~type/oracle-server-types'
 import { OracleAnnouncementsResponse } from '~type/oracle-explorer-types'
-import { getMessageBody, } from '~util/message-util'
+
+import { getMessageBody } from '~util/oracle-server-util'
+
+import { BlockstreamService } from './blockstream-service'
+import { MessageService } from './message.service'
+import { OracleExplorerService } from './oracle-explorer.service'
 
 
 type OracleEventMap = { [eventName: string]: OracleEvent }
@@ -14,6 +17,11 @@ type OracleAnnouncementMap = { [eventName: string]: OracleAnnouncementsResponse 
 
 @Injectable({ providedIn: 'root' })
 export class OracleStateService {
+
+  // oracleName = '' // lives on OracleExpolorer service for now
+  publicKey = ''
+  stakingAddress = ''
+  stakedAmount = ''
 
   // Server state
   eventNames: BehaviorSubject<string[]> = new BehaviorSubject<string[]>([])
@@ -33,10 +41,51 @@ export class OracleStateService {
     this.announcements.next(Object.assign({}, this.announcements.value))
   }
 
-  constructor(private messageService: MessageService, private oracleExplorerService: OracleExplorerService) {
+  constructor(private messageService: MessageService, private oracleExplorerService: OracleExplorerService, 
+    private blockstreamService: BlockstreamService) {
     this.oracleExplorerService.oracleExplorer.subscribe(oe => {
       this.getLocalEventAnnouncements().subscribe() // Check for announcements on new Explorer selection
     })
+
+    this.getPublicKeyAndOracleName()
+    this.getStakingAddressAndBalance()
+  }
+
+  getPublicKeyAndOracleName() {
+    console.debug('getPublicKeyAndOracleName()')
+    this.messageService.sendMessage(getMessageBody(MessageType.getpublickey)).subscribe(result => {
+      if (result.result) {
+        this.publicKey = result.result
+        if (!this.oracleExplorerService.oracleName.value) {
+          this.getOracleName()
+        }
+      }
+    })
+  }
+
+  getOracleName() {
+    this.oracleExplorerService.getLocalOracleName(this.publicKey).subscribe(result => {
+      console.debug(' getOracleName()', result)
+    })
+  }
+
+  getStakingAddressAndBalance() {
+    console.debug('getStakingAddressAndBalance()')
+    this.messageService.sendMessage(getMessageBody(MessageType.getstakingaddress)).subscribe(result => {
+      if (result.result) {
+        this.stakingAddress = result.result
+        this.getStakingBalance()
+      }
+    })
+  }
+
+  getStakingBalance() {
+    console.debug('getStakingBalance()')
+    if (this.stakingAddress) {
+      this.blockstreamService.getBalance(this.stakingAddress).subscribe(result => {
+        this.stakedAmount = this.blockstreamService.balanceFromGetBalance(result).toString()
+      })
+    }
   }
 
   getAllEvents() {

--- a/oracle-server-ui/src/service/tor.service.ts
+++ b/oracle-server-ui/src/service/tor.service.ts
@@ -8,6 +8,8 @@ const TOR_KEY = 'USE_TOR'
 
 const DEFAULT_USE_TOR = false
 
+// const TOR_ERROR_THRESHOLD = 0
+
 @Injectable({ providedIn: 'root' })
 export class TorService {
 
@@ -17,8 +19,17 @@ export class TorService {
     localStorage.setItem(TOR_KEY, value.toString())
   }
   get useTor() {
+    // if (this._errors > TOR_ERROR_THRESHOLD) {
+    //   return false;
+    // }
     return this._useTor
   }
+
+  // Could track error count and doing something here...
+  // private _errors = 0
+  // addError() {
+  //   ++this._errors
+  // }
 
   constructor() {
     const value = localStorage.getItem(TOR_KEY)

--- a/oracle-server-ui/src/service/tor.service.ts
+++ b/oracle-server-ui/src/service/tor.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core'
+
+import { stringToBoolean } from '~util/ui-util'
+
+
+// LocalStorage Keys
+const TOR_KEY = 'USE_TOR'
+
+const DEFAULT_USE_TOR = true
+
+@Injectable({ providedIn: 'root' })
+export class TorService {
+
+  private _useTor: boolean
+  set useTor(value: boolean) {
+    this._useTor = value
+    localStorage.setItem(TOR_KEY, value.toString())
+  }
+  get useTor() {
+    return this._useTor
+  }
+
+  constructor() {
+    const value = localStorage.getItem(TOR_KEY)
+    this._useTor = value ? stringToBoolean(value) : DEFAULT_USE_TOR
+    console.warn('useTor:', this.useTor)
+  }
+
+}

--- a/oracle-server-ui/src/service/tor.service.ts
+++ b/oracle-server-ui/src/service/tor.service.ts
@@ -6,7 +6,7 @@ import { stringToBoolean } from '~util/ui-util'
 // LocalStorage Keys
 const TOR_KEY = 'USE_TOR'
 
-const DEFAULT_USE_TOR = true
+const DEFAULT_USE_TOR = false
 
 @Injectable({ providedIn: 'root' })
 export class TorService {

--- a/oracle-server-ui/src/styles.scss
+++ b/oracle-server-ui/src/styles.scss
@@ -45,3 +45,13 @@ body { margin: 0; }
 .close-button {
   align-self: center;
 }
+
+// Center checkbox in pseudo-mat-form-field
+.mat-form-field--checkbox {
+  display: flex;
+  flex-direction: row;
+
+  mat-checkbox {
+    margin: auto;
+  }
+}

--- a/oracle-server-ui/src/styles.scss
+++ b/oracle-server-ui/src/styles.scss
@@ -33,7 +33,7 @@
 
 
 html, body { height: 100%; }
-// body { font-family: Roboto, "Helvetica Neue", sans-serif; }
+body { font-family: Roboto, "Helvetica Neue", sans-serif; }
 body { margin: 0; }
 
 .section-header {

--- a/oracle-server-ui/src/type/proxy-server-types.ts
+++ b/oracle-server-ui/src/type/proxy-server-types.ts
@@ -1,3 +1,4 @@
+import { Observable } from 'rxjs'
 
 // Heartbeat response type
 export type SuccessType = { success: boolean }
@@ -7,4 +8,26 @@ export interface BuildConfig {
   hash: string
   committedOn: number
   dateString?: string
+}
+
+export const CONNECTION_REFUSED_ERROR = /connection refused/
+export const TOR_CONNECTION_REFUSED_ERROR = /tor connection refused/
+
+type ProxyErrorFn = (message: string) => void
+
+export function getProxyErrorHandler(name: string, onError: ProxyErrorFn) {
+  return (error: any, caught: Observable<unknown>) => {
+    console.error('OracleExplorer errorHandler', error)
+    const statusText = error?.statusText
+    if (CONNECTION_REFUSED_ERROR.test(statusText)) {
+      console.error('tor connection failed')
+      // Could record error count here...
+    }
+    let message = error?.message
+    if (onError) {
+      onError(message)
+    }
+    throw(Error(`${name} error`)) // forces failure out of forkJoin() of operations
+    return new Observable<any>() // required for type checking...
+  }
 }

--- a/oracle-server-ui/src/util/oracle-server-util.ts
+++ b/oracle-server-ui/src/util/oracle-server-util.ts
@@ -1,0 +1,57 @@
+import { OracleServerMessage, OracleServerMessageWithParameters } from '~type/oracle-server-message'
+import { MessageType } from '~type/oracle-server-types'
+
+
+export function getMessageBody(type: MessageType, params?: any[]): OracleServerMessage {
+  switch (type) {
+    case MessageType.getpublickey:
+    case MessageType.getstakingaddress:
+    case MessageType.listevents:
+    case MessageType.getversion: // Common
+      return new OracleServerMessage(type)
+    case MessageType.getevent:
+    case MessageType.signevent:
+    case MessageType.signdigits:
+    case MessageType.signmessage:
+    case MessageType.getsignatures:
+    case MessageType.createenumevent:
+    case MessageType.createnumericevent:
+    case MessageType.createdigitdecompevent:
+      return new OracleServerMessageWithParameters(type, params!)
+    default:
+      throw(Error('getMessageBody() unknown message type: ' + type))
+  }
+}
+
+export function formatOutcomes(outcomes: any[]): string {
+  if (outcomes && outcomes.length > 0) {
+    const head = outcomes[0]
+    if (Array.isArray(head) && head.length === 2) {
+      // numeric outcomes
+      const signed = head[0] === '+' && head[1] === '-'
+      const exp = signed ? outcomes.length - 1 : outcomes.length
+      const outcome = (2 ** exp) - 1
+      return signed ? '-' + outcome + '..' + outcome : '0..' + outcome
+    } else {
+      // enum and all other outcomes
+      return '' + outcomes
+    }
+  } else {
+    return ''
+  }
+}
+
+export function outcomesToMinMax(outcomes: any[]) {
+  if (outcomes && outcomes.length > 0) {
+    const head = outcomes[0]
+    if (Array.isArray(head) && head.length === 2) {
+      // numeric outcomes
+      const signed = head[0] === '+' && head[1] === '-'
+      const exp = signed ? outcomes.length - 1 : outcomes.length
+      const outcome = (2 ** exp) - 1
+      const min = signed ? -outcome : 0
+      return { min, max: outcome }
+    }
+  }
+  return null
+}

--- a/oracle-server-ui/src/util/ui-util.ts
+++ b/oracle-server-ui/src/util/ui-util.ts
@@ -6,3 +6,6 @@ export const KrystalBullImages: string[] = ['/assets/image/300x300/krystal_bull.
 // '/assets/image/300x300/krystal_bull_green.jpeg', '/assets/image/300x300/krystal_bull_indigo.jpeg', '/assets/image/300x300/krystal_bull_orange.jpeg',
 // '/assets/image/300x300/krystal_bull_purple.jpeg']
 
+export function stringToBoolean(s: string | null) {
+  return s === 'true'
+}


### PR DESCRIPTION
Add tor support to the proxy server and /tor prefixed endpoints for choosing to use. Added loading indicators and config selection for tor.

![Screen Shot 2021-09-29 at 1 25 24 PM](https://user-images.githubusercontent.com/22351459/135335333-d40c64d3-dd35-4da0-bec5-da559feaddad.png)

Individual announcement loading looks like last item here:
![Screen Shot 2021-09-29 at 1 26 52 PM](https://user-images.githubusercontent.com/22351459/135335462-7bc0d7c9-3e4c-46d8-a13c-1a689e8f6500.png)