### PR TITLE
2021 10 10 oracle server npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,7 @@ name: npm-publish
 on:
   push:
     branches:
-      [master, main, 2021-10-10-oracle-server-npm-publish] # Change this to your default branch
+      [master, main] # Change this to your default branch
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 15
+          node-version: 16
       - run: cd oracle-server-ts
       - run: npm install
       - name: Set outputs
@@ -24,3 +24,4 @@ jobs:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
           package: oracle-server-ts/package.json
           tag: "${{steps.vars.outputs.sha_short}}"
+          check-version: true # will not publish unless version is changed

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-# https://github.com/marketplace/actions/publish-to-npm
+# https://github.com/JS-DevTools/npm-publish
 name: npm-publish
 on:
   push:
@@ -12,9 +12,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 10
+      - run: cd oracle-server-ts
       - run: npm install
       - run: npm test
-      
       - name: Set outputs
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short=8 HEAD)"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,21 @@
+# https://github.com/marketplace/actions/publish-to-npm
+name: npm-publish
+on:
+  push:
+    branches:
+      - [master, main, 2021-10-10-oracle-server-npm-publish] # Change this to your default branch
+jobs:
+  npm-publish:
+    name: npm-publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Publish if version has been updated
+      uses: pascalgn/npm-publish-action@1.3.8
+      with: # All of theses inputs are optional
+        create_tag: "false"
+        workspace: "oracle-server-ts"
+      env: # More info about the environment variables in the README
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # You need to set this in your repo settings

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: [14.x, 15.x, 16.x]
       - run: cd oracle-server-ts
       - run: npm install
       - name: Set outputs

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,6 @@ jobs:
           node-version: 10
       - run: cd oracle-server-ts
       - run: npm install
-      - run: npm test
       - name: Set outputs
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short=8 HEAD)"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,7 @@ name: npm-publish
 on:
   push:
     branches:
-      - [master, main, 2021-10-10-oracle-server-npm-publish] # Change this to your default branch
+      [master, main, 2021-10-10-oracle-server-npm-publish] # Change this to your default branch
 jobs:
   npm-publish:
     name: npm-publish

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: [14.x, 15.x, 16.x]
+          node-version: 15
       - run: cd oracle-server-ts
       - run: npm install
       - name: Set outputs

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,17 +5,23 @@ on:
     branches:
       [master, main, 2021-10-10-oracle-server-npm-publish] # Change this to your default branch
 jobs:
-  npm-publish:
-    name: npm-publish
+  publish:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-    - name: Publish if version has been updated
-      uses: pascalgn/npm-publish-action@1.3.8
-      with: # All of theses inputs are optional
-        create_tag: "false"
-        workspace: "oracle-server-ts"
-      env: # More info about the environment variables in the README
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # You need to set this in your repo settings
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - run: npm install
+      - run: npm test
+      
+      - name: Set outputs
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short=8 HEAD)"
+      - name: Check outputs
+        run: echo ${{ steps.vars.outputs.sha_short }}
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_AUTH_TOKEN }}
+          package: oracle-server-ts/package.json
+          tag: "${{steps.vars.outputs.sha_short}}"

--- a/oracle-server-ts/package-lock.json
+++ b/oracle-server-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "oracle-server-ts",
-  "version": "0.0.1",
+  "name": "@bitcoin-s-ts/oracle-server-ts",
+  "version": "0.0.1-LOCAL",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.1",
-      "license": "MIT",
+      "name": "@bitcoin-s-ts/oracle-server-ts",
+      "version": "0.0.1-LOCAL",
       "dependencies": {
         "needle": "^3.0.0"
       },

--- a/oracle-server-ts/package.json
+++ b/oracle-server-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitcoin-s-ts/oracle-server-ts",
-  "version": "0.0.1-LOCAL",
+  "version": "0.0.1",
   "description": "NodeJS package for accessing bitcoin-s oracleServer",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/oracle-server-ts/package.json
+++ b/oracle-server-ts/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "oracle-server-ts",
-  "version": "0.0.1",
+  "name": "@bitcoin-s-ts/oracle-server-ts",
+  "version": "0.0.1-LOCAL",
   "description": "NodeJS package for accessing bitcoin-s oracleServer",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,6 @@
     "demo": "npx ts-node demo.ts",
     "tests": "npx ts-node tests.ts"
   },
-  "private": true,
   "dependencies": {
     "needle": "^3.0.0"
   },


### PR DESCRIPTION
Publishes oracle-server rpc library on npm

https://www.npmjs.com/package/@bitcoin-s-ts/oracle-server-ts

This is the workflow i decided to go with: https://github.com/JS-DevTools/npm-publish

An open question is versioning, but if I understand the `check-version` setting from `npm-publish` it will check if the versions are the same as available on npm, and if they are the same, it doesn't publish. 

I can't really test this until 

1. We merge this PR into master
2. We merge a second PR into master and confirm that the build didn't trigger
3. We merge a 3rd PR that bumps the version and confirm that the new version shows up on npmjs