### PR TITLE
2021 10 11 npm publish bug

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,6 +23,6 @@ jobs:
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
-          package: oracle-server-ts/package.json
+          package: ./oracle-server-ts/package.json
           tag: "${{steps.vars.outputs.sha_short}}"
           check-version: true # will not publish unless version is changed

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,5 +24,5 @@ jobs:
         with:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
           package: ./oracle-server-ts/package.json
-          tag: "${{steps.vars.outputs.sha_short}}"
+          #tag: "${{steps.vars.outputs.sha_short}}"
           check-version: true # will not publish unless version is changed

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,4 +24,5 @@ jobs:
         with:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
           package: oracle-server-ts/package.json
+          tag: "${{steps.vars.outputs.sha_short}}"
           check-version: true # will not publish unless version is changed

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,7 @@ name: npm-publish
 on:
   push:
     branches:
-      [master, main] # Change this to your default branch
+      [master, main, 2021-10-11-npm-publish-bug] # Change this to your default branch
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -24,5 +24,4 @@ jobs:
         with:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
           package: oracle-server-ts/package.json
-          tag: "${{steps.vars.outputs.sha_short}}"
           check-version: true # will not publish unless version is changed

--- a/oracle-server-ts/package.json
+++ b/oracle-server-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitcoin-s-ts/oracle-server-ts",
-  "version": "0.0.1-LOCAL",
+  "version": "0.0.1",
   "description": "NodeJS package for accessing bitcoin-s oracleServer",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/oracle-server-ts/package.json
+++ b/oracle-server-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitcoin-s-ts/oracle-server-ts",
-  "version": "0.0.1",
+  "version": "0.0.1-LOCAL",
   "description": "NodeJS package for accessing bitcoin-s oracleServer",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
fixes a bug introduced in #28 

`npm-publish` action works by looking up the `latest` tag on npmjs. I happened to publish version `0.0.1-LOCAL` with the latest tag on our registry

![Screenshot from 2021-10-11 13-24-48](https://user-images.githubusercontent.com/3514957/136836894-b6fdfb6b-6032-4efa-b0dd-88c3d3e44bf8.png)

The `check-version` features for `npm-publish` works like this: 

It checks the combination of version (`0.0.1-LOCAL`) and the the local version (`0.0.1`) and finds the semantically versioned difference. However, since I already published a `0.0.1` that did NOT have the `latest` tag, `npm-publish` doesn't recognize it. 

npmjs itself recognizes that it has a (`0.0.1`) and fails to publish. 

https://github.com/bitcoin-s/bitcoin-s-ts/runs/3862187376#step:7:57

The only way i can see of how to get around this is by bumping the `oracle-server-ts` project to 0.0.2. I cannot see how to delete the `0.0.1-LOCAL` version on npmjs, i've tried doing `npm unpublish @bitcoin-s-ts/oracle-server-ts@0.0.1-LOCAL` locally but it doesn't seem to remove it from npmjs.org

![Screenshot from 2021-10-11 13-27-53](https://user-images.githubusercontent.com/3514957/136837252-1e49578a-8c7a-4754-b208-623f9cd5ee7d.png)
