### PR TITLE
Bump oracle server version to 0.0.2 to test publish

### DIFF
--- a/oracle-server-ts/package.json
+++ b/oracle-server-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitcoin-s-ts/oracle-server-ts",
-  "version": "0.0.1-LOCAL",
+  "version": "0.0.2",
   "description": "NodeJS package for accessing bitcoin-s oracleServer",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Step 3 from testing PR #28

>We merge a 3rd PR that bumps the version and confirm that the new version shows up on npmjs