### PR TITLE
Small UI updates based on design review meeting feedback

### DIFF
--- a/oracle-server-ui/src/app/announcement-detail/announcement-detail.component.html
+++ b/oracle-server-ui/src/app/announcement-detail/announcement-detail.component.html
@@ -32,8 +32,9 @@
           <mat-label translate>outcome</mat-label>
           <input matInput name="signEnum" type="text" [(ngModel)]="signEnumInput" 
             placeholder="{{ announcement.outcomes.join() }}">
+          <mat-hint *ngIf="signEnumInput && !announcement.outcomes.includes(signEnumInput)" align="start" translate [translateParams]="{ outcomes: announcement.outcomes.join() }">announcementDetail.outcomeMustBeInSet</mat-hint>
         </mat-form-field>
-        <button mat-raised-button color="primary" (click)="onSignEnum()">
+        <button class="sign-button" mat-raised-button color="primary" (click)="onSignEnum()" [disabled]="!announcement.outcomes.includes(signEnumInput)">
           {{ 'oracleOperations.signenum' | translate }}</button>
       </ng-container>
       <ng-container *ngIf="isNotEnum()">
@@ -42,7 +43,7 @@
           <input matInput name="signDigits" type="number" [(ngModel)]="signDigitsInput" 
             placeholder="{{ formatOutcomes(announcement.outcomes) }}">
         </mat-form-field>
-        <button mat-raised-button color="primary" (click)="onSignDigits()">
+        <button class="sign-button" mat-raised-button color="primary" (click)="onSignDigits()">
           {{ 'oracleOperations.signdigits' | translate }}</button>
       </ng-container>
     </ng-container>
@@ -104,7 +105,12 @@
     </ng-container>
   </div>
 
-  <div class="json">
+  <button *ngIf="!showAnnouncementJSON" mat-stroked-button 
+    (click)="onShowAnnouncementJSON(); $event.stopPropagation()">
+    <span class="button-label" translate>announcementDetail.showAnnouncementJSON</span>
+  </button>
+
+  <div *ngIf="showAnnouncementJSON" class="json">
     <label translate>announcementDetail.eventJSON</label>
     <textarea class="announcement-json">{{ announcement | json }}</textarea>
   </div>

--- a/oracle-server-ui/src/app/announcement-detail/announcement-detail.component.scss
+++ b/oracle-server-ui/src/app/announcement-detail/announcement-detail.component.scss
@@ -15,6 +15,10 @@
     }
   }
 
+  .sign-button {
+    margin-top: 1rem;
+  }
+
   .status {
     display: flex;
     flex-direction: column;

--- a/oracle-server-ui/src/app/announcement-detail/announcement-detail.component.ts
+++ b/oracle-server-ui/src/app/announcement-detail/announcement-detail.component.ts
@@ -37,6 +37,8 @@ export class AnnouncementDetailComponent implements OnInit {
   showSigningSuccess = false
   showAttestationDeleted = false
 
+  showAnnouncementJSON = false
+
   private reset() {
     this.signEnumInput = ''
     this.signDigitsInput = undefined
@@ -189,6 +191,11 @@ export class AnnouncementDetailComponent implements OnInit {
         this.oracleState.getOEAnnouncement(this.announcement).subscribe() // Update oracleState
       }
     })
+  }
+
+  onShowAnnouncementJSON() {
+    console.debug('onShowAnnouncementJSON()')
+    this.showAnnouncementJSON = true
   }
 
   onClose() {

--- a/oracle-server-ui/src/app/new-announcement/new-announcement.component.html
+++ b/oracle-server-ui/src/app/new-announcement/new-announcement.component.html
@@ -13,6 +13,10 @@
         [value]="e">{{ 'announcementType.' + e | translate }}</mat-radio-button>
     </mat-radio-group>
 
+    <div class="description">
+      {{ 'createAnnouncement.description.' + announcementType | translate }}
+    </div>
+
     <mat-form-field>
       <mat-label translate>createAnnouncement.name</mat-label>
       <!-- TODO : Initial focus -- cdkFocusInitial -->
@@ -28,6 +32,7 @@
         placeholder="{{ 'createAnnouncement.maturationTimePlaceholder' | translate }}">
       <mat-datepicker-toggle matSuffix [for]="datePicker"></mat-datepicker-toggle>
       <mat-datepicker #datePicker></mat-datepicker>
+      <app-more-info matSuffix tooltip="createAnnouncementDescription.maturationTime"></app-more-info>
     </mat-form-field>
 
     <mat-form-field *ngIf="announcementType === AnnouncementType.ENUM">

--- a/oracle-server-ui/src/app/new-announcement/new-announcement.component.scss
+++ b/oracle-server-ui/src/app/new-announcement/new-announcement.component.scss
@@ -17,6 +17,10 @@
       margin-bottom: 1.5rem;
     }
 
+    .description {
+      margin-bottom: 1rem;
+    }
+
     button {
       margin-top: 0.75rem;
     }

--- a/oracle-server-ui/src/app/new-announcement/new-announcement.component.ts
+++ b/oracle-server-ui/src/app/new-announcement/new-announcement.component.ts
@@ -164,7 +164,7 @@ export class NewAnnouncementComponent implements OnInit {
       maxValue: [null, [conditionalValidator(() => this.announcementType === AnnouncementType.NUMERIC,
         Validators.required)]],
       unit: [null, Validators.required],
-      precision: [null, conditionalValidator(() => this.announcementType === AnnouncementType.DIGIT_DECOMP || this.announcementType === AnnouncementType.NUMERIC, 
+      precision: [0, conditionalValidator(() => this.announcementType === AnnouncementType.DIGIT_DECOMP || this.announcementType === AnnouncementType.NUMERIC, 
         Validators.compose([nonNegativeNumberValidator(), Validators.required]))],
       // base: [null, [conditionalValidator(() => this.eventType === EventType.DIGIT_DECOMP,
       //   positiveNumberValidator())]],

--- a/oracle-server-ui/src/assets/i18n/en.json
+++ b/oracle-server-ui/src/assets/i18n/en.json
@@ -140,6 +140,11 @@
       "created": "Announcement Created Successfully"
     },
 
+    "description": {
+      "enum": "This announcement type has a fixed set of possible outcomes",
+      "numeric": "This announcement type has a numeric range of outcomes"
+    },
+
     "name": "Name",
     "namePlaceholder": "Unique Announcement Name",
     "maturationTime": "Maturation Time",
@@ -196,7 +201,9 @@
     "announcementIsNotBroadcast": "This announcement is not broadcast",
     "outcomeIsBroadcast": "This announcement outcome is broadcast",
     "outcomeIsNotBroadcast": "This announcement outcome is not broadcast",
-    "deleteAnnouncement": "Delete Announcement"
+    "deleteAnnouncement": "Delete Announcement",
+    "showAnnouncementJSON": "Show Announcement JSON",
+    "outcomeMustBeInSet": "The outcome must be one of {{ outcomes }}"
   },
 
   "action": {


### PR DESCRIPTION
Adds description to enum/numeric announcement types on New Announcement.
Add help text for maturationTime.
Default precision on numeric announcements to zero.
Validate enumerated outcome entry before allowing signing.
Show Announcement JSON via button click.

![Screen Shot 2021-10-19 at 12 50 14 PM](https://user-images.githubusercontent.com/22351459/137973091-7426333a-2a62-4d49-b956-4895e832d54a.png)

![Screen Shot 2021-10-19 at 12 49 44 PM](https://user-images.githubusercontent.com/22351459/137973114-b7e129ce-460c-48b5-ae02-35245dd070b6.png)

![Screen Shot 2021-10-19 at 12 49 26 PM](https://user-images.githubusercontent.com/22351459/137973146-93411920-50f4-4e61-a4c7-92d2cf165218.png)


