### PR TITLE
Add npm preinstall step to install common-ts dependencies from wallet-ts

### DIFF
--- a/common-ts/package-lock.json
+++ b/common-ts/package-lock.json
@@ -1,11 +1,10 @@
 {
-  "name": "oracle-server-ts",
+  "name": "common-ts",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "oracle-server-ts",
       "version": "0.0.1",
       "dependencies": {
         "needle": "^3.0.0"

--- a/wallet-ts/package-lock.json
+++ b/wallet-ts/package-lock.json
@@ -5,8 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "wallet-ts",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "dependencies": {
         "needle": "^3.0.0"
       },

--- a/wallet-ts/package.json
+++ b/wallet-ts/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
+    "preinstall": "cd ../common-ts && npm i",
     "prepublish": "npm run build",
     "build": "tsc",
     "tests": "npx ts-node tests.ts"


### PR DESCRIPTION
I think there is an outstanding issue with wallet-ts using common-ts and not having `npm i`ed common-ts. This makes sure that happens. I saw this issue with a fresh repo on Ubuntu trying to use wallet-ts after `npm i`.