### PR TITLE
Wallet server UI 003

### DIFF
--- a/wallet-server-ui-proxy/server.ts
+++ b/wallet-server-ui-proxy/server.ts
@@ -235,7 +235,7 @@ if (USE_TOR_PROXY) {
 
 /** Oracle Server Proxy */
 
-// Proxy calls to this server to oracleServer/run instance
+// Proxy calls to this server to appServer/run or bundle/run instance
 const PROXY_TIMEOUT = 10 * 1000; // 10 seconds
 app.use(Config.apiRoot, createProxyMiddleware({
   target: walletServerUrl,
@@ -247,7 +247,7 @@ app.use(Config.apiRoot, createProxyMiddleware({
   onError: (err: Error, req: Request, res: Response) => {
     // Handle oracleServer is unavailable
     if (err && (<any>err).code === ECONNREFUSED) {
-      res.writeHead(500, 'oracleServer connection refused').end()
+      res.writeHead(500, 'appServer connection refused').end()
     } else {
       logger.error('onError', err, res.statusCode, res.statusMessage)
     }

--- a/wallet-server-ui/angular.json
+++ b/wallet-server-ui/angular.json
@@ -45,8 +45,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumWarning": "10kb",
+                  "maximumError": "150kb"
                 }
               ],
               "fileReplacements": [

--- a/wallet-server-ui/src/app/app.component.html
+++ b/wallet-server-ui/src/app/app.component.html
@@ -31,6 +31,7 @@
           <!-- (close)="onCloseContractDetail()" -->
           <app-contract-detail *ngIf="selectedDLC && selectedDLCContractInfo" 
             [dlc]="selectedDLC" [contractInfo]="selectedDLCContractInfo"
+            (close)="onContractDetailClose()"
           ></app-contract-detail>
         </div>
       </div>

--- a/wallet-server-ui/src/app/app.component.html
+++ b/wallet-server-ui/src/app/app.component.html
@@ -4,9 +4,49 @@
 
   <mat-sidenav-container>
     <mat-sidenav-content>
-
       <!-- Main -->
 
+      <div class="main-content">
+        <app-build-accept-offer
+          (announcement)="onAnnouncement($event)" 
+          (contractInfo)="onContractInfo($event)"
+          (acceptOffer)="onAcceptOffer($event)">
+        </app-build-accept-offer>
+
+        <app-wallet-balance></app-wallet-balance>
+
+        <app-contracts #contracts (selectedDLC)="onSelectedDLC($event)"></app-contracts>
+
+        <div *ngIf="walletStateService.torDLCHostAddress" class="tor-dlc-host-address">
+          <label translate>torDLCHostAddress</label>
+          <input [value]="walletStateService.torDLCHostAddress" disabled>
+          <button mat-icon-button class="copy-button" matTooltip="{{ 'action.copyToClipboard' | translate }}"
+            (click)="onCopyTorDLCHostAddress()"><mat-icon>content_copy</mat-icon></button>
+        </div>
+
+        <div *ngIf="walletStateService.info" class="state-info">
+          <div class="network" translate="status.networkLabel" [translateParams]="{ network : walletStateService.info.network }"></div>
+          <div class="block-height" translate="status.blockHeightLabel" [translateParams]="{ height: walletStateService.info.blockHeight }"></div>
+          <div class="fee-estimate" translate="status.feeEstimateLabel" [translateParams]="{ fee: walletStateService.feeEstimate }"></div>
+          <div class="config">
+            <button mat-stroked-button (click)="showConfiguration()">Config</button>
+          </div>
+        </div>
+  
+        <div class="footer">
+          <div class="footer-section">
+            <span class="label" translate>server</span>
+            <span class="server-version">{{ walletStateService.serverVersion }}</span>
+          </div>
+          <div *ngIf="walletStateService.buildConfig" class="footer-section">
+            <span class="label" translate>ui</span>
+            <span class="version">{{ walletStateService.buildConfig.shortHash }}</span>
+            <span class="date">{{ walletStateService.buildConfig.dateString }}</span>
+          </div>
+        </div>
+      </div>
+
+      <!--
       <div class="horizontal-pane">
         <div class="left-pane">
           <app-build-accept-offer
@@ -20,7 +60,6 @@
           <app-contracts #contracts (selectedDLC)="onSelectedDLC($event)"></app-contracts>
         </div>
         <div class="right-pane">
-          <!-- Don't like having two instances, but avoids null handling logic -->
           <app-new-offer #buildOffer *ngIf="selectedAnnouncement" 
             [announcement]="selectedAnnouncement"
             (close)="onNewOfferClose()"></app-new-offer>
@@ -31,63 +70,39 @@
           <app-accept-offer #acceptOffer *ngIf="selectedOffer" [offer]="selectedOffer"
             (close)="onAcceptOfferClose()"></app-accept-offer>
 
-          <!-- (close)="onCloseContractDetail()" -->
           <app-contract-detail *ngIf="selectedDLC && selectedDLCContractInfo" 
             [dlc]="selectedDLC" [contractInfo]="selectedDLCContractInfo"
             (close)="onContractDetailClose()"
           ></app-contract-detail>
         </div>
       </div>
-      
-      <!--
-      <button mat-stroked-button color="primary">Primary</button>
-      <button mat-stroked-button color="accent">Accent</button>
-      <button mat-stroked-button color="warn">Warn</button>
-      -->
-      
-      <!-- <div class="fundedAddresses">
-        {{ walletStateService.fundedAddresses | json }}
-      </div> -->
-
-      <div>
-        <!-- <button mat-stroked-button (click)="createContractInfo()">Create Contract Info</button> -->
-      </div>
-
-      <div>
-        <!-- <button mat-stroked-button (click)="makeNewOffer()">Make New Offer</button> -->
-      </div>
-
-      <div *ngIf="walletStateService.torDLCHostAddress" class="tor-dlc-host-address">
-        <label translate>torDLCHostAddress</label>
-        <input [value]="walletStateService.torDLCHostAddress" disabled>
-        <button mat-icon-button class="copy-button" matTooltip="{{ 'action.copyToClipboard' | translate }}"
-          (click)="onCopyTorDLCHostAddress()"><mat-icon>content_copy</mat-icon></button>
-      </div>
-
-      <div *ngIf="walletStateService.info" class="state-info">
-        <div class="network" translate="status.networkLabel" [translateParams]="{ network : walletStateService.info.network }"></div>
-        <div class="block-height" translate="status.blockHeightLabel" [translateParams]="{ height: walletStateService.info.blockHeight }"></div>
-        <div class="fee-estimate" translate="status.feeEstimateLabel" [translateParams]="{ fee: walletStateService.feeEstimate }"></div>
-        <div class="config">
-          <button mat-stroked-button (click)="showConfiguration()">Config</button>
-        </div>
-      </div>
-
-      <div class="footer">
-        <div class="footer-section">
-          <span class="label" translate>server</span>
-          <span class="server-version">{{ walletStateService.serverVersion }}</span>
-        </div>
-        <div *ngIf="walletStateService.buildConfig" class="footer-section">
-          <span class="label" translate>ui</span>
-          <span class="version">{{ walletStateService.buildConfig.shortHash }}</span>
-          <span class="date">{{ walletStateService.buildConfig.dateString }}</span>
-        </div>
-      </div>
+    -->
     </mat-sidenav-content>
 
     <mat-sidenav #rightDrawer position="end" mode="over">
-      <app-configuration (close)="onConfigurationClose()" (rootClassName)="onRootClassName($event)"></app-configuration>
+      <div class="drawer-container">
+        <app-configuration *ngIf="configurationVisible"
+          (close)="onConfigurationClose()" (rootClassName)="onRootClassName($event)"></app-configuration>
+
+        <app-contract-detail *ngIf="contractDetailsVisible && selectedDLC && selectedDLCContractInfo" 
+          [dlc]="selectedDLC" [contractInfo]="selectedDLCContractInfo"
+          (close)="onContractDetailClose()"
+        ></app-contract-detail>
+
+        <ng-container *ngIf="offerVisible">
+          <!-- Don't like having two instances, but avoids null handling logic -->
+          <app-new-offer #buildOffer *ngIf="selectedAnnouncement" 
+            [announcement]="selectedAnnouncement"
+            (close)="onNewOfferClose()"></app-new-offer>
+          <app-new-offer #buildOffer *ngIf="selectedContractInfo" 
+            [contractInfo]="selectedContractInfo"
+            (close)="onNewOfferClose()"></app-new-offer>
+
+          <app-accept-offer #acceptOffer *ngIf="selectedOffer" [offer]="selectedOffer"
+            (close)="onAcceptOfferClose()"></app-accept-offer>
+        </ng-container>
+
+      </div>
     </mat-sidenav>
 
   </mat-sidenav-container>

--- a/wallet-server-ui/src/app/app.component.html
+++ b/wallet-server-ui/src/app/app.component.html
@@ -7,22 +7,30 @@
 
       <!-- Main -->
 
-      <button mat-stroked-button (click)="showConfiguration()">Config</button>
+      <div class="horizontal-pane">
+        <div class="left-pane">
+          <app-build-accept-offer
+          (announcement)="onAnnouncement($event)" 
+          (contractInfo)="onContractInfo($event)"
+          (offer)="onOffer($event)"
+          (acceptOffer)="onAcceptOffer($event)"></app-build-accept-offer>
+  
+          <app-wallet-balance></app-wallet-balance>
+  
+          <app-contracts #contracts (selectedDLC)="onSelectedDLC($event)"></app-contracts>
+        </div>
+        <div class="right-pane">
+          <app-new-offer #buildOffer *ngIf="selectedAnnouncement" [announcement]="selectedAnnouncement"></app-new-offer>
 
-      <app-build-accept-offer
-        (announcement)="onAnnouncement($event)" 
-        (contractInfo)="onContractInfo($event)"
-        (offer)="onOffer($event)"
-        (acceptOffer)="onAcceptOffer($event)"></app-build-accept-offer>
+          <app-accept-offer #acceptOffer *ngIf="selectedOffer" [offer]="selectedOffer"></app-accept-offer>
 
-      <app-wallet-balance></app-wallet-balance>
-
-      <app-contracts></app-contracts>
-
-      <app-new-offer #buildOffer></app-new-offer>
-
-      <app-accept-offer #acceptOffer></app-accept-offer>
-
+          <!-- (close)="onCloseContractDetail()" -->
+          <app-contract-detail *ngIf="selectedDLC && selectedContractInfo" 
+            [dlc]="selectedDLC" [contractInfo]="selectedContractInfo"
+          ></app-contract-detail>
+        </div>
+      </div>
+      
       <!--
       <button mat-stroked-button color="primary">Primary</button>
       <button mat-stroked-button color="accent">Accent</button>
@@ -41,10 +49,20 @@
         <!-- <button mat-stroked-button (click)="makeNewOffer()">Make New Offer</button> -->
       </div>
 
+      <div *ngIf="walletStateService.torDLCHostAddress" class="tor-dlc-host-address">
+        <label translate>torDLCHostAddress</label>
+        <input [value]="walletStateService.torDLCHostAddress" disabled>
+        <button mat-icon-button class="copy-button" matTooltip="{{ 'action.copyToClipboard' | translate }}"
+          (click)="onCopyTorDLCHostAddress()"><mat-icon>content_copy</mat-icon></button>
+      </div>
+
       <div *ngIf="walletStateService.info" class="state-info">
         <div class="network" translate="status.networkLabel" [translateParams]="{ network : walletStateService.info.network }"></div>
         <div class="block-height" translate="status.blockHeightLabel" [translateParams]="{ height: walletStateService.info.blockHeight }"></div>
         <div class="fee-estimate" translate="status.feeEstimateLabel" [translateParams]="{ fee: walletStateService.feeEstimate }"></div>
+        <div class="config">
+          <button mat-stroked-button (click)="showConfiguration()">Config</button>
+        </div>
       </div>
 
       <div class="footer">

--- a/wallet-server-ui/src/app/app.component.html
+++ b/wallet-server-ui/src/app/app.component.html
@@ -22,11 +22,14 @@
         <div class="right-pane">
           <!-- Don't like having two instances, but avoids null handling logic -->
           <app-new-offer #buildOffer *ngIf="selectedAnnouncement" 
-            [announcement]="selectedAnnouncement"></app-new-offer>
+            [announcement]="selectedAnnouncement"
+            (close)="onNewOfferClose()"></app-new-offer>
           <app-new-offer #buildOffer *ngIf="selectedContractInfo" 
-            [contractInfo]="selectedContractInfo"></app-new-offer>
+            [contractInfo]="selectedContractInfo"
+            (close)="onNewOfferClose()"></app-new-offer>
 
-          <app-accept-offer #acceptOffer *ngIf="selectedOffer" [offer]="selectedOffer"></app-accept-offer>
+          <app-accept-offer #acceptOffer *ngIf="selectedOffer" [offer]="selectedOffer"
+            (close)="onAcceptOfferClose()"></app-accept-offer>
 
           <!-- (close)="onCloseContractDetail()" -->
           <app-contract-detail *ngIf="selectedDLC && selectedDLCContractInfo" 

--- a/wallet-server-ui/src/app/app.component.html
+++ b/wallet-server-ui/src/app/app.component.html
@@ -10,23 +10,27 @@
       <div class="horizontal-pane">
         <div class="left-pane">
           <app-build-accept-offer
-          (announcement)="onAnnouncement($event)" 
-          (contractInfo)="onContractInfo($event)"
-          (offer)="onOffer($event)"
-          (acceptOffer)="onAcceptOffer($event)"></app-build-accept-offer>
+            (announcement)="onAnnouncement($event)" 
+            (contractInfo)="onContractInfo($event)"
+            (acceptOffer)="onAcceptOffer($event)">
+          </app-build-accept-offer>
   
           <app-wallet-balance></app-wallet-balance>
   
           <app-contracts #contracts (selectedDLC)="onSelectedDLC($event)"></app-contracts>
         </div>
         <div class="right-pane">
-          <app-new-offer #buildOffer *ngIf="selectedAnnouncement" [announcement]="selectedAnnouncement"></app-new-offer>
+          <!-- Don't like having two instances, but avoids null handling logic -->
+          <app-new-offer #buildOffer *ngIf="selectedAnnouncement" 
+            [announcement]="selectedAnnouncement"></app-new-offer>
+          <app-new-offer #buildOffer *ngIf="selectedContractInfo" 
+            [contractInfo]="selectedContractInfo"></app-new-offer>
 
           <app-accept-offer #acceptOffer *ngIf="selectedOffer" [offer]="selectedOffer"></app-accept-offer>
 
           <!-- (close)="onCloseContractDetail()" -->
-          <app-contract-detail *ngIf="selectedDLC && selectedContractInfo" 
-            [dlc]="selectedDLC" [contractInfo]="selectedContractInfo"
+          <app-contract-detail *ngIf="selectedDLC && selectedDLCContractInfo" 
+            [dlc]="selectedDLC" [contractInfo]="selectedDLCContractInfo"
           ></app-contract-detail>
         </div>
       </div>

--- a/wallet-server-ui/src/app/app.component.scss
+++ b/wallet-server-ui/src/app/app.component.scss
@@ -7,10 +7,21 @@
     height: 100%;
   }
 
+  .tor-dlc-host-address {
+    label {
+      margin-right: 1rem;
+    }
+    input {
+      display: inline-block;
+      width: 28rem;
+    }
+  }
+
   .state-info {
     display: flex;
     flex-direction: row;
     justify-content: space-around;
+    align-items: center;
 
     .network {
 
@@ -26,6 +37,8 @@
   .footer {
     display: flex;
     justify-content: center;
+    align-items: center;
+
     font-size: smaller;
     color: #8c959f;
     

--- a/wallet-server-ui/src/app/app.component.scss
+++ b/wallet-server-ui/src/app/app.component.scss
@@ -1,10 +1,17 @@
 .content-root {
   height: 100%;
 
-  padding: 1rem;
+  .main-content {
+    padding: 1rem;
+  }
 
   .mat-sidenav-container {
     height: 100%;
+  }
+
+  .drawer-container {
+    padding: 0 1rem;
+    min-width: 300px;
   }
 
   .tor-dlc-host-address {

--- a/wallet-server-ui/src/app/app.component.ts
+++ b/wallet-server-ui/src/app/app.component.ts
@@ -171,6 +171,18 @@ export class AppComponent implements OnInit {
     copyToClipboard(this.walletStateService.torDLCHostAddress)
   }
 
+  onNewOfferClose() {
+    console.debug('onNewOfferClose()')
+
+    this.hideOffers()
+  }
+
+  onAcceptOfferClose() {
+    console.debug('onAcceptOfferClose()')
+
+    this.hideOffers()
+  }
+
   onContractDetailClose() {
     console.debug('onContractDetailClose()')
 

--- a/wallet-server-ui/src/app/app.component.ts
+++ b/wallet-server-ui/src/app/app.component.ts
@@ -38,11 +38,14 @@ export class AppComponent implements OnInit {
   // Root styling class to support darkMode
   @HostBinding('class') className = ''
 
+  // Build
   selectedAnnouncement: AnnouncementWithHex|null
+  selectedContractInfo: ContractInfoWithHex|null
+  // Accept
   selectedOffer: OfferWithHex|null
 
   selectedDLC: DLCContract|null
-  selectedContractInfo: ContractInfo|null
+  selectedDLCContractInfo: ContractInfo|null
 
   constructor(private titleService: Title, private translate: TranslateService, public messageService: MessageService, private snackBar: MatSnackBar, private overlay: OverlayContainer,
     public walletStateService: WalletStateService) {
@@ -119,32 +122,23 @@ export class AppComponent implements OnInit {
     console.debug('onAnnouncement()', announcement)
 
     this.hideOffers()
-
     this.selectedAnnouncement = announcement
-    // this.buildOffer.announcement = announcement
-
     this.hideSelectedDLC()
   }
 
   onContractInfo(contractInfo: ContractInfoWithHex) {
     console.debug('onContractInfo()', contractInfo)
 
-    console.error('onContractInfo() NOT HANDLED YET')
-  }
-
-  onOffer(offer: OfferWithHex) {
-    console.debug('onOffer()', offer)
-
-    console.error('onOffer() NOT HANDLED YET')
+    this.hideOffers()
+    this.selectedContractInfo = contractInfo
+    this.hideSelectedDLC()
   }
 
   onAcceptOffer(offer: OfferWithHex) {
     console.debug('onAcceptOffer()', offer)
 
     this.hideOffers()
-    
     this.selectedOffer = offer
-    // this.acceptOffer.offer = offer
     this.hideSelectedDLC()
   }
 
@@ -152,7 +146,7 @@ export class AppComponent implements OnInit {
     console.debug('onSelectedDLC()')
 
     this.selectedDLC = dlcContractInfo.dlc
-    this.selectedContractInfo = dlcContractInfo.contractInfo
+    this.selectedDLCContractInfo = dlcContractInfo.contractInfo
 
     this.hideOffers()    
   }
@@ -160,11 +154,12 @@ export class AppComponent implements OnInit {
   private hideSelectedDLC() {
     this.contracts.clearSelection()
     this.selectedDLC = null
-    this.selectedContractInfo = null
+    this.selectedDLCContractInfo = null
   }
 
   private hideOffers() {
     this.selectedAnnouncement = null
+    this.selectedContractInfo = null
     this.selectedOffer = null
     
     // this.buildOffer.announcement = <AnnouncementWithHex><unknown>null

--- a/wallet-server-ui/src/app/app.component.ts
+++ b/wallet-server-ui/src/app/app.component.ts
@@ -9,10 +9,12 @@ import { TranslateService } from '@ngx-translate/core'
 import { MessageService } from '~service/message.service'
 import { WalletStateService } from '~service/wallet-state-service'
 import { BuildConfig } from '~type/proxy-server-types'
-import { Announcement, ContractInfo, DLCMessageType, Offer, WalletMessageType } from '~type/wallet-server-types'
+import { Announcement, ContractInfo, DLCContract, DLCMessageType, Offer, WalletMessageType } from '~type/wallet-server-types'
 import { AnnouncementWithHex, ContractInfoWithHex, OfferWithHex } from '~type/wallet-ui-types'
+import { copyToClipboard } from '~util/utils'
 import { getMessageBody } from '~util/wallet-server-util'
 import { AcceptOfferComponent } from './component/accept-offer/accept-offer.component'
+import { ContractsComponent, DLCContractInfo } from './component/contracts/contracts.component'
 import { NewOfferComponent } from './component/new-offer/new-offer.component'
 
 
@@ -31,9 +33,16 @@ export class AppComponent implements OnInit {
 
   @ViewChild('buildOffer') buildOffer: NewOfferComponent
   @ViewChild('acceptOffer') acceptOffer: AcceptOfferComponent
+  @ViewChild('contracts') contracts: ContractsComponent
 
   // Root styling class to support darkMode
   @HostBinding('class') className = ''
+
+  selectedAnnouncement: AnnouncementWithHex|null
+  selectedOffer: OfferWithHex|null
+
+  selectedDLC: DLCContract|null
+  selectedContractInfo: ContractInfo|null
 
   constructor(private titleService: Title, private translate: TranslateService, public messageService: MessageService, private snackBar: MatSnackBar, private overlay: OverlayContainer,
     public walletStateService: WalletStateService) {
@@ -109,25 +118,63 @@ export class AppComponent implements OnInit {
   onAnnouncement(announcement: AnnouncementWithHex) {
     console.debug('onAnnouncement()', announcement)
 
-    this.buildOffer.announcement = announcement;
+    this.hideOffers()
+
+    this.selectedAnnouncement = announcement
+    // this.buildOffer.announcement = announcement
+
+    this.hideSelectedDLC()
   }
 
   onContractInfo(contractInfo: ContractInfoWithHex) {
     console.debug('onContractInfo()', contractInfo)
 
-    console.warn('onContractInfo() NOT HANDLED YET')
+    console.error('onContractInfo() NOT HANDLED YET')
   }
 
   onOffer(offer: OfferWithHex) {
     console.debug('onOffer()', offer)
 
-    console.warn('onOffer() NOT HANDLED YET')
+    console.error('onOffer() NOT HANDLED YET')
   }
 
   onAcceptOffer(offer: OfferWithHex) {
     console.debug('onAcceptOffer()', offer)
+
+    this.hideOffers()
     
-    this.acceptOffer.offer = offer
+    this.selectedOffer = offer
+    // this.acceptOffer.offer = offer
+    this.hideSelectedDLC()
   }
 
+  onSelectedDLC(dlcContractInfo: DLCContractInfo) {
+    console.debug('onSelectedDLC()')
+
+    this.selectedDLC = dlcContractInfo.dlc
+    this.selectedContractInfo = dlcContractInfo.contractInfo
+
+    this.hideOffers()    
+  }
+
+  private hideSelectedDLC() {
+    this.contracts.clearSelection()
+    this.selectedDLC = null
+    this.selectedContractInfo = null
+  }
+
+  private hideOffers() {
+    this.selectedAnnouncement = null
+    this.selectedOffer = null
+    
+    // this.buildOffer.announcement = <AnnouncementWithHex><unknown>null
+    // this.acceptOffer.offer = <OfferWithHex><unknown>null
+  }
+
+  onCopyTorDLCHostAddress() {
+    console.debug('onCopyTorDLCHostAddress()', this.walletStateService.torDLCHostAddress)
+    copyToClipboard(this.walletStateService.torDLCHostAddress)
+  }
+
+  
 }

--- a/wallet-server-ui/src/app/app.component.ts
+++ b/wallet-server-ui/src/app/app.component.ts
@@ -47,6 +47,10 @@ export class AppComponent implements OnInit {
   selectedDLC: DLCContract|null
   selectedDLCContractInfo: ContractInfo|null
 
+  configurationVisible = false
+  offerVisible = false
+  contractDetailsVisible = false
+  
   constructor(private titleService: Title, private translate: TranslateService, public messageService: MessageService, private snackBar: MatSnackBar, private overlay: OverlayContainer,
     public walletStateService: WalletStateService) {
     
@@ -70,11 +74,19 @@ export class AppComponent implements OnInit {
 
   showConfiguration() {
     console.debug('showConfiguration()')
-    this.rightDrawer.toggle()
+
+    this.configurationVisible = true
+    this.offerVisible = false
+    this.contractDetailsVisible = false
+
+    this.rightDrawer.open()
   }
 
   onConfigurationClose() {
     console.debug('onConfigurationClose()')
+
+    this.configurationVisible = false
+
     this.rightDrawer.close()
   }
 
@@ -124,6 +136,8 @@ export class AppComponent implements OnInit {
     this.hideOffers()
     this.selectedAnnouncement = announcement
     this.hideSelectedDLC()
+    this.offerVisible = true
+    this.rightDrawer.open()
   }
 
   onContractInfo(contractInfo: ContractInfoWithHex) {
@@ -132,6 +146,8 @@ export class AppComponent implements OnInit {
     this.hideOffers()
     this.selectedContractInfo = contractInfo
     this.hideSelectedDLC()
+    this.offerVisible = true
+    this.rightDrawer.open()
   }
 
   onAcceptOffer(offer: OfferWithHex) {
@@ -140,6 +156,8 @@ export class AppComponent implements OnInit {
     this.hideOffers()
     this.selectedOffer = offer
     this.hideSelectedDLC()
+    this.offerVisible = true
+    this.rightDrawer.open()
   }
 
   onSelectedDLC(dlcContractInfo: DLCContractInfo) {
@@ -148,16 +166,22 @@ export class AppComponent implements OnInit {
     this.selectedDLC = dlcContractInfo.dlc
     this.selectedDLCContractInfo = dlcContractInfo.contractInfo
 
-    this.hideOffers()    
+    this.hideOffers()
+    this.contractDetailsVisible = true
+    this.rightDrawer.open()
   }
 
   private hideSelectedDLC() {
+    this.contractDetailsVisible = false
+
     this.contracts.clearSelection()
     this.selectedDLC = null
     this.selectedDLCContractInfo = null
   }
 
   private hideOffers() {
+    this.offerVisible = false
+
     this.selectedAnnouncement = null
     this.selectedContractInfo = null
     this.selectedOffer = null
@@ -174,18 +198,21 @@ export class AppComponent implements OnInit {
   onNewOfferClose() {
     console.debug('onNewOfferClose()')
 
+    this.rightDrawer.close()
     this.hideOffers()
   }
 
   onAcceptOfferClose() {
     console.debug('onAcceptOfferClose()')
 
+    this.rightDrawer.close()
     this.hideOffers()
   }
 
   onContractDetailClose() {
     console.debug('onContractDetailClose()')
 
+    this.rightDrawer.close()
     this.hideSelectedDLC()
   }
 

--- a/wallet-server-ui/src/app/app.component.ts
+++ b/wallet-server-ui/src/app/app.component.ts
@@ -171,5 +171,11 @@ export class AppComponent implements OnInit {
     copyToClipboard(this.walletStateService.torDLCHostAddress)
   }
 
+  onContractDetailClose() {
+    console.debug('onContractDetailClose()')
+
+    this.hideSelectedDLC()
+  }
+
   
 }

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
@@ -1,7 +1,9 @@
 <section class="accept-offer" *ngIf="offer">
   <div class="section-header">
     <h2 translate>acceptOffer.heading</h2>
-    <!-- <button mat-icon-button class="close-button" (click)="onClose()"><mat-icon>close</mat-icon></button> -->
+    <button mat-icon-button class="close-button" matTooltip="{{ 'action.close' | translate }}" (click)="onClose()">
+      <mat-icon>close</mat-icon>
+    </button>
   </div>
 
   <div>
@@ -9,6 +11,10 @@
       <div class="field-group">
         <label translate>acceptOffer.eventId</label>
         <input class="wide-input" [value]="contractInfo.oracleInfo.announcement.event.eventId" disabled>
+      </div>
+      <div class="field-group">
+        <label translate>acceptOffer.maturityDate</label>
+        <input [value]="maturityDate" disabled>
       </div>
 
       <div class="spacer"></div>
@@ -86,7 +92,8 @@
 
       <div class="field-group">
         <label translate>acceptOffer.peerAddress</label>
-        <input type="text" placeholder="{{ 'acceptOffer.optional' | translate }}" [(ngModel)]="peerAddress">
+        <!-- 'acceptOffer.optional' -->
+        <input type="text" placeholder="{{ 'acceptOffer.required' | translate }}" [(ngModel)]="peerAddress">
         <app-more-info matSuffix tooltip="acceptOfferDescription.peerAddress"></app-more-info>
       </div>
     </div>

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
@@ -51,18 +51,18 @@
     </div>
 
     <div *ngIf="isNumeric()" class="numeric-offer">
-      <!-- <div class="field-group">
-        <label translate>acceptOffer.yourCollateral</label>
-        <input [value]="contractInfo.totalCollateral - offer.offer.offerCollateralSatoshis">
+      <div class="outcome-group">
+        <div class="numeric-payout-group">
+          <label class="outcome-label text-center" translate>newOffer.outcome</label>
+          <label class="payout-label text-center" translate>newOffer.payout</label>
+          <label class="endpoint-label text-center" translate>newOffer.endpoint</label>
+        </div>
+        <div *ngFor="let point of numericContractDescriptor.payoutFunction.points; let i = index" class="numeric-payout-group">
+          <input class="text-right" type="number" [(ngModel)]="point.outcome" disabled>
+          <input class="text-right" type="number" placeholder="{{ 'unit.satoshis' | translate }}" [(ngModel)]="point.payout" disabled>
+          <input type="checkbox" [(ngModel)]="point.isEndpoint" disabled>
+        </div>
       </div>
-      <div class="field-group">
-        <label translate>acceptOffer.counterpartyCollateral</label>
-        <input [value]="offer.offer.offerCollateralSatoshis">
-      </div> -->
-      <div class="payout-curve">
-        TODO : Payout curve
-      </div>
-      
     </div>
 
     <div class="both">

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
@@ -1,37 +1,38 @@
-<section class="accept-offer">
+<section class="accept-offer" *ngIf="offer">
   <div class="section-header">
     <h2 translate>acceptOffer.heading</h2>
     <!-- <button mat-icon-button class="close-button" (click)="onClose()"><mat-icon>close</mat-icon></button> -->
   </div>
 
-  <div *ngIf="offer">
-
+  <div>
     <div class="both">
       <div class="field-group">
-        <label translate>acceptOffer.dlcOffer</label>
-        <input [value]="offer.hex" disabled>
-      </div>
-      <div class="field-group">
-        <label translate>acceptOffer.peerAddress</label>
-        <input type="text" placeholder="{{ 'acceptOffer.optional' | translate }}" [(ngModel)]="peerAddress">
-        <app-more-info matSuffix tooltip="acceptOfferDescription.peerAddress"></app-more-info>
-      </div>
-      <div class="field-group">
         <label translate>acceptOffer.eventId</label>
-        <input [value]="contractInfo.oracleInfo.announcement.event.eventId" disabled>
+        <input class="wide-input" [value]="contractInfo.oracleInfo.announcement.event.eventId" disabled>
+      </div>
+      <div class="field-group">
+        <label translate>acceptOffer.dlcOffer</label>
+        <input class="wide-input" [value]="offer.hex" disabled>
       </div>
       <div class="field-group">
         <label translate>acceptOffer.oraclePublicKey</label>
-        <input [value]="contractInfo.oracleInfo.announcement.publicKey" disabled>
+        <input class="wide-input" [value]="contractInfo.oracleInfo.announcement.publicKey" disabled>
       </div>
-
+      <div class="spacer"></div>
       <div class="field-group">
         <label translate>acceptOffer.yourCollateral</label>
-        <input [value]="offer.offer.offerCollateralSatoshis - contractInfo.totalCollateral" disabled>
+        <input [value]="contractInfo.totalCollateral - offer.offer.offerCollateralSatoshis" disabled>
+        <span translate>unit.sats</span>
       </div>
       <div class="field-group">
         <label translate>acceptOffer.counterpartyCollateral</label>
         <input [value]="offer.offer.offerCollateralSatoshis" disabled>
+        <span translate>unit.sats</span>
+      </div>
+      <div class="field-group">
+        <label translate>acceptOffer.totalCollateral</label>
+        <input [value]="contractInfo.totalCollateral" disabled>
+        <span translate>unit.sats</span>
       </div>
     </div>
 
@@ -44,7 +45,7 @@
         </div>
         <div *ngFor="let label of Object.keys(enumContractDescriptor.outcomes)" class="field-group">
           <label>{{ label }}</label>
-          <input type="number" [(ngModel)]="enumContractDescriptor.outcomes[label]" disabled>
+          <input type="number" [value]="contractInfo.totalCollateral - enumContractDescriptor.outcomes[label]" disabled>
         </div>
       </div>
     </div>
@@ -59,7 +60,7 @@
         <input [value]="offer.offer.offerCollateralSatoshis">
       </div> -->
       <div class="payout-curve">
-        TODO : Payout curve preview
+        TODO : Payout curve
       </div>
       
     </div>
@@ -68,10 +69,17 @@
       <div class="field-group">
         <label translate>acceptOffer.feeRate</label>
         <input [value]="offer.offer.feeRatePerVb" disabled>
+        <span translate>unit.satsPerVbyte</span>
       </div>
       <div class="field-group">
         <label translate>acceptOffer.refundDate</label>
-        <input [value]="offer.offer.refundLocktime" disabled>
+        <input [value]="refundDate" disabled>
+      </div>
+      <div class="spacer"></div>
+      <div class="field-group">
+        <label translate>acceptOffer.peerAddress</label>
+        <input type="text" placeholder="{{ 'acceptOffer.optional' | translate }}" [(ngModel)]="peerAddress">
+        <app-more-info matSuffix tooltip="acceptOfferDescription.peerAddress"></app-more-info>
       </div>
     </div>
 

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
@@ -12,27 +12,16 @@
         <label translate>acceptOffer.eventId</label>
         <input class="wide-input" [value]="contractInfo.oracleInfo.announcement.event.eventId" disabled>
       </div>
+
+      <div class="spacer"></div>
+      
       <div class="field-group">
         <label translate>acceptOffer.maturityDate</label>
         <input [value]="maturityDate" disabled>
       </div>
-
-      <div class="spacer"></div>
-
       <div class="field-group">
-        <label translate>acceptOffer.yourCollateral</label>
-        <input [value]="contractInfo.totalCollateral - offer.offer.offerCollateralSatoshis" disabled>
-        <span translate>unit.sats</span>
-      </div>
-      <div class="field-group">
-        <label translate>acceptOffer.counterpartyCollateral</label>
-        <input [value]="offer.offer.offerCollateralSatoshis" disabled>
-        <span translate>unit.sats</span>
-      </div>
-      <div class="field-group">
-        <label translate>acceptOffer.totalCollateral</label>
-        <input [value]="contractInfo.totalCollateral" disabled>
-        <span translate>unit.sats</span>
+        <label translate>acceptOffer.refundDate</label>
+        <input [value]="refundDate" disabled>
       </div>
     </div>
 
@@ -68,13 +57,19 @@
 
     <div class="both">
       <div class="field-group">
-        <label translate>acceptOffer.refundDate</label>
-        <input [value]="refundDate" disabled>
+        <label translate>acceptOffer.yourCollateral</label>
+        <input [value]="contractInfo.totalCollateral - offer.offer.offerCollateralSatoshis" disabled>
+        <span translate>unit.sats</span>
       </div>
       <div class="field-group">
-        <label translate>acceptOffer.feeRate</label>
-        <input [value]="offer.offer.feeRatePerVb" disabled>
-        <span translate>unit.satsPerVbyte</span>
+        <label translate>acceptOffer.counterpartyCollateral</label>
+        <input [value]="offer.offer.offerCollateralSatoshis" disabled>
+        <span translate>unit.sats</span>
+      </div>
+      <div class="field-group">
+        <label translate>acceptOffer.totalCollateral</label>
+        <input [value]="contractInfo.totalCollateral" disabled>
+        <span translate>unit.sats</span>
       </div>
 
       <div class="spacer"></div>
@@ -91,6 +86,14 @@
       <div class="spacer"></div>
 
       <div class="field-group">
+        <label translate>acceptOffer.feeRate</label>
+        <input [value]="offer.offer.feeRatePerVb" disabled>
+        <span translate>unit.satsPerVbyte</span>
+      </div>
+
+      <div class="spacer"></div>
+
+      <div class="field-group">
         <label translate>acceptOffer.peerAddress</label>
         <!-- 'acceptOffer.optional' -->
         <input type="text" placeholder="{{ 'acceptOffer.required' | translate }}" [(ngModel)]="peerAddress">
@@ -102,7 +105,9 @@
       <div class="button-group">
         <button mat-stroked-button color="primary" (click)="onExecute()" [disabled]="!peerAddress">{{ 'action.execute' | translate }}</button>
       </div>
+
       <fieldset class="result-group" [disabled]="!newOfferResult">
+        <label translate>result</label>
         <textarea class="result-textarea" [(ngModel)]="newOfferResult"></textarea>
         <button mat-icon-button class="copy-button" matTooltip="{{ 'action.copyToClipboard' | translate }}"
           (click)="onCopyResult()"><mat-icon>content_copy</mat-icon></button>

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
@@ -10,15 +10,9 @@
         <label translate>acceptOffer.eventId</label>
         <input class="wide-input" [value]="contractInfo.oracleInfo.announcement.event.eventId" disabled>
       </div>
-      <div class="field-group">
-        <label translate>acceptOffer.dlcOffer</label>
-        <input class="wide-input" [value]="offer.hex" disabled>
-      </div>
-      <div class="field-group">
-        <label translate>acceptOffer.oraclePublicKey</label>
-        <input class="wide-input" [value]="contractInfo.oracleInfo.announcement.publicKey" disabled>
-      </div>
+
       <div class="spacer"></div>
+
       <div class="field-group">
         <label translate>acceptOffer.yourCollateral</label>
         <input [value]="contractInfo.totalCollateral - offer.offer.offerCollateralSatoshis" disabled>
@@ -59,7 +53,8 @@
         </div>
         <div *ngFor="let point of numericContractDescriptor.payoutFunction.points; let i = index" class="numeric-payout-group">
           <input class="text-right" type="number" [(ngModel)]="point.outcome" disabled>
-          <input class="text-right" type="number" placeholder="{{ 'unit.satoshis' | translate }}" [(ngModel)]="point.payout" disabled>
+          <input class="text-right" type="number" placeholder="{{ 'unit.satoshis' | translate }}"
+            [(ngModel)]="contractInfo.totalCollateral - point.payout" disabled>
           <input type="checkbox" [(ngModel)]="point.isEndpoint" disabled>
         </div>
       </div>
@@ -67,15 +62,28 @@
 
     <div class="both">
       <div class="field-group">
+        <label translate>acceptOffer.refundDate</label>
+        <input [value]="refundDate" disabled>
+      </div>
+      <div class="field-group">
         <label translate>acceptOffer.feeRate</label>
         <input [value]="offer.offer.feeRatePerVb" disabled>
         <span translate>unit.satsPerVbyte</span>
       </div>
-      <div class="field-group">
-        <label translate>acceptOffer.refundDate</label>
-        <input [value]="refundDate" disabled>
-      </div>
+
       <div class="spacer"></div>
+
+      <div class="field-group">
+        <label translate>acceptOffer.dlcOffer</label>
+        <input class="wide-input" [value]="offer.hex" disabled>
+      </div>
+      <div class="field-group">
+        <label translate>acceptOffer.oraclePublicKey</label>
+        <input class="wide-input" [value]="contractInfo.oracleInfo.announcement.publicKey" disabled>
+      </div>
+
+      <div class="spacer"></div>
+
       <div class="field-group">
         <label translate>acceptOffer.peerAddress</label>
         <input type="text" placeholder="{{ 'acceptOffer.optional' | translate }}" [(ngModel)]="peerAddress">
@@ -85,7 +93,7 @@
 
     <div class="footer">
       <div class="button-group">
-        <button mat-stroked-button color="primary" (click)="onExecute()">{{ 'action.execute' | translate }}</button>
+        <button mat-stroked-button color="primary" (click)="onExecute()" [disabled]="!peerAddress">{{ 'action.execute' | translate }}</button>
       </div>
       <fieldset class="result-group" [disabled]="!newOfferResult">
         <textarea class="result-textarea" [(ngModel)]="newOfferResult"></textarea>

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.scss
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.scss
@@ -43,6 +43,10 @@
 
       align-items: center;
 
+      &:first-of-type {
+        margin-bottom: 0.5rem;
+      }
+
       // Alignment here is currently ghetto
       label.outcome-label {
         display: inline-block;
@@ -67,18 +71,8 @@
   }
 
   .footer {
-    // display: flex;
-    // flex-direction: row;
-    width: 36rem;
     .button-group {
       text-align: right;
-    }
-    .result-group {
-      // flex: 1;
-
-      .result-textarea {
-        width: 80%;
-      }
     }
   }
 

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.scss
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.scss
@@ -33,15 +33,36 @@
           width: 10rem;
         }
         label.payout-label {
-          width: 24rem;
+          width: 10rem;
         }
+      }
+    }
+    .numeric-payout-group {
+      display: flex;
+      flex-direction: row;
+
+      align-items: center;
+
+      // Alignment here is currently ghetto
+      label.outcome-label {
+        display: inline-block;
+        width: 6.5rem;
+      }
+      label.payout-label {
+        display: inline-block;
+        width: 6.5rem;
+      }
+      input[type="number"] {
+        width: 6rem;
+        margin-right: 0.25rem;
+      }
+      input[type="checkbox"] {
+        width: 3rem;
+        vertical-align: middle;
       }
     }
     .spacer {
       height: 1rem;
-    }
-    .payout-curve {
-      margin: 2rem;
     }
   }
 

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.scss
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.scss
@@ -8,7 +8,13 @@
       }
       input {
         display: inline-block;
-        width: 24rem;
+        width: 10rem;
+      }
+      .wide-input {
+        width: 16rem;
+      }
+      span {
+        margin-left: 0.4rem;
       }
     }
     .outcome-group {
@@ -31,7 +37,9 @@
         }
       }
     }
-
+    .spacer {
+      height: 1rem;
+    }
     .payout-curve {
       margin: 2rem;
     }

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.ts
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.ts
@@ -6,7 +6,7 @@ import { WalletStateService } from '~service/wallet-state-service'
 
 import { Offer, EnumContractDescriptor, NumericContractDescriptor, WalletMessageType, DLCMessageType } from '~type/wallet-server-types'
 import { OfferWithHex } from '~type/wallet-ui-types'
-import { copyToClipboard } from '~util/utils'
+import { copyToClipboard, formatDateTime } from '~util/utils'
 import { getMessageBody } from '~util/wallet-server-util'
 
 
@@ -37,19 +37,20 @@ export class AcceptOfferComponent implements OnInit {
     return <EnumContractDescriptor>this.offer.offer.contractInfo.contractDescriptor
   }
 
-  // isEnum = false
-  // isNumeric = false
-
-  peerAddress = ''
+  get numericContractDescriptor() {
+    return <NumericContractDescriptor>this.offer.offer.contractInfo.contractDescriptor
+  }
 
   refundDate: string
 
-  newOfferResult: string = ''
+  peerAddress: string
+
+  newOfferResult: string
 
   private reset() {
-    // this.isEnum = (<EnumContractDescriptor>this.offer.contractInfo.contractDescriptor).outcomes !== undefined
-    // this.isNumeric = (<NumericContractDescriptor>this.offer.contractInfo.contractDescriptor).numDigits !== undefined
-    this.refundDate = new Date(this.offer.offer.refundLocktime * 1000).toLocaleDateString()
+    this.refundDate = formatDateTime(this.offer.offer.refundLocktime)
+    this.peerAddress = ''
+    this.newOfferResult = ''
   }
 
   constructor(private messageService: MessageService, private walletStateService: WalletStateService, private dialog: MatDialog) { }
@@ -58,21 +59,17 @@ export class AcceptOfferComponent implements OnInit {
   }
 
   isEnum() {
-    const cd = this.contractDescriptor
-    // if (cd instanceof EnumContractDescriptor) return true
-    // return <EnumContractDescriptor>cd !== undefined
-    return (<EnumContractDescriptor>cd).outcomes !== undefined
+    const cd = <EnumContractDescriptor>this.contractDescriptor
+    return cd.outcomes !== undefined
   }
 
   isNumeric() {
-    const cd = this.contractDescriptor
-    // return this.offer.contractInfo.contractDescriptor instanceof NumericContractDescriptor
-    return (<NumericContractDescriptor>cd).numDigits !== undefined
+    const cd = <NumericContractDescriptor>this.contractDescriptor
+    return cd.numDigits !== undefined
   }
 
   onExecute() {
     console.debug('onExecute()')
-
 
     let pa
     if (this.peerAddress) {
@@ -91,7 +88,7 @@ export class AcceptOfferComponent implements OnInit {
           }
         })
     } else {
-      console.warn('not using Tor for acceptdlc is untested')
+      console.error('not using Tor for acceptdlc is untested')
 
       const dialog = this.dialog.open(ErrorDialogComponent, {
         data: {

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.ts
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.ts
@@ -1,4 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core'
+import { MatDialog } from '@angular/material/dialog'
+import { ErrorDialogComponent } from '~app/dialog/error/error.component'
 import { MessageService } from '~service/message.service'
 import { WalletStateService } from '~service/wallet-state-service'
 
@@ -50,7 +52,7 @@ export class AcceptOfferComponent implements OnInit {
     this.refundDate = new Date(this.offer.offer.refundLocktime * 1000).toLocaleDateString()
   }
 
-  constructor(private messageService: MessageService, private walletStateService: WalletStateService) { }
+  constructor(private messageService: MessageService, private walletStateService: WalletStateService, private dialog: MatDialog) { }
 
   ngOnInit(): void {
   }
@@ -80,8 +82,6 @@ export class AcceptOfferComponent implements OnInit {
     }
 
     if (pa) {
-      console.warn('not using Tor for acceptdlc is untested')
-      // DLCOfferTLV, torAddress
       this.messageService.sendMessage(getMessageBody(DLCMessageType.acceptdlc,
         [this.offer.hex, pa])).subscribe(r => {
           console.warn('acceptdlcoffer', r)
@@ -91,6 +91,17 @@ export class AcceptOfferComponent implements OnInit {
           }
         })
     } else {
+      console.warn('not using Tor for acceptdlc is untested')
+
+      const dialog = this.dialog.open(ErrorDialogComponent, {
+        data: {
+          title: 'dialog.mempoolError.title',
+          content: 'Accepting DLCs without using Tor is not currently enabled',
+        }
+      })
+
+      return
+
       this.messageService.sendMessage(getMessageBody(WalletMessageType.acceptdlcoffer,
         [this.offer.hex])).subscribe(r => {
           console.warn('acceptdlcoffer', r)

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.ts
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core'
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core'
 import { MatDialog } from '@angular/material/dialog'
 import { ErrorDialogComponent } from '~app/dialog/error/error.component'
 import { MessageService } from '~service/message.service'
@@ -6,7 +6,7 @@ import { WalletStateService } from '~service/wallet-state-service'
 
 import { Offer, EnumContractDescriptor, NumericContractDescriptor, WalletMessageType, DLCMessageType } from '~type/wallet-server-types'
 import { OfferWithHex } from '~type/wallet-ui-types'
-import { copyToClipboard, formatDateTime, validateTorAddress } from '~util/utils'
+import { copyToClipboard, formatDateTime, formatISODate, validateTorAddress } from '~util/utils'
 import { getMessageBody } from '~util/wallet-server-util'
 
 
@@ -41,13 +41,23 @@ export class AcceptOfferComponent implements OnInit {
     return <NumericContractDescriptor>this.offer.offer.contractInfo.contractDescriptor
   }
 
+  get announcement() {
+    return this.offer.offer.contractInfo.oracleInfo.announcement
+  }
+
+  get event() {
+    return this.offer.offer.contractInfo.oracleInfo.announcement.event
+  }
+
+  @Output() close: EventEmitter<void> = new EventEmitter()
+
+  maturityDate: string
   refundDate: string
-
   peerAddress: string
-
   newOfferResult: string
 
   private reset() {
+    this.maturityDate = formatISODate(this.event.maturity)
     this.refundDate = formatDateTime(this.offer.offer.refundLocktime)
     this.peerAddress = ''
     this.newOfferResult = ''
@@ -56,6 +66,10 @@ export class AcceptOfferComponent implements OnInit {
   constructor(private messageService: MessageService, private walletStateService: WalletStateService, private dialog: MatDialog) { }
 
   ngOnInit(): void {
+  }
+
+  onClose() {
+    this.close.next()
   }
 
   isEnum() {

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.ts
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.ts
@@ -79,29 +79,26 @@ export class AcceptOfferComponent implements OnInit {
       pa = this.peerAddress
     }
 
-    if (this.isEnum()) {
-      if (pa) {
-        // DLCOfferTLV, torAddress
-        this.messageService.sendMessage(getMessageBody(DLCMessageType.acceptdlc,
-          [this.offer.hex, pa])).subscribe(r => {
-            console.warn('acceptdlcoffer', r)
-            if (r.result) {
-              this.newOfferResult = r.result
-              this.walletStateService.refreshDLCStates()
-            }
-          })
-      } else {
-        this.messageService.sendMessage(getMessageBody(WalletMessageType.acceptdlcoffer,
-          [this.offer.hex])).subscribe(r => {
-            console.warn('acceptdlcoffer', r)
-            if (r.result) {
-              this.newOfferResult = r.result
-              this.walletStateService.refreshDLCStates()
-            }
-          })
-      }
-    } else if (this.isNumeric()) {
-
+    if (pa) {
+      console.warn('not using Tor for acceptdlc is untested')
+      // DLCOfferTLV, torAddress
+      this.messageService.sendMessage(getMessageBody(DLCMessageType.acceptdlc,
+        [this.offer.hex, pa])).subscribe(r => {
+          console.warn('acceptdlcoffer', r)
+          if (r.result) {
+            this.newOfferResult = r.result
+            this.walletStateService.refreshDLCStates()
+          }
+        })
+    } else {
+      this.messageService.sendMessage(getMessageBody(WalletMessageType.acceptdlcoffer,
+        [this.offer.hex])).subscribe(r => {
+          console.warn('acceptdlcoffer', r)
+          if (r.result) {
+            this.newOfferResult = r.result
+            this.walletStateService.refreshDLCStates()
+          }
+        })
     }
   }
 

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.ts
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.ts
@@ -19,8 +19,8 @@ export class AcceptOfferComponent implements OnInit {
 
   private _offer: OfferWithHex
   @Input() set offer (offer: OfferWithHex) {
-    this.reset()
     this._offer = offer
+    this.reset()
   }
   get offer() { return this._offer }
 
@@ -40,11 +40,14 @@ export class AcceptOfferComponent implements OnInit {
 
   peerAddress = ''
 
+  refundDate: string
+
   newOfferResult: string = ''
 
   private reset() {
     // this.isEnum = (<EnumContractDescriptor>this.offer.contractInfo.contractDescriptor).outcomes !== undefined
     // this.isNumeric = (<NumericContractDescriptor>this.offer.contractInfo.contractDescriptor).numDigits !== undefined
+    this.refundDate = new Date(this.offer.offer.refundLocktime * 1000).toLocaleDateString()
   }
 
   constructor(private messageService: MessageService, private walletStateService: WalletStateService) { }

--- a/wallet-server-ui/src/app/component/build-accept-offer/build-accept-offer.component.html
+++ b/wallet-server-ui/src/app/component/build-accept-offer/build-accept-offer.component.html
@@ -7,10 +7,11 @@
     <label translate>buildAcceptOffer.buildOffer</label>
     <input #buildOfferInput type="text" placeholder="{{ 'buildAcceptOffer.pasteHex' | translate }}"
       (paste)="onBuildOfferPaste($event)" (input)="onBuildOfferInput($event)">
-    <div hidden>
-      <button mat-stroked-button (click)="onBuildOffer(enumAnnouncementHex)">New Enum</button>
-      <button mat-stroked-button (click)="onBuildOffer(numericAnnouncementHex)">New Numeric</button>
-    </div>
+  </div>
+
+  <div>
+    <button mat-stroked-button (click)="onBuildOffer(enumAnnouncementHex)">New Enum</button>
+    <button mat-stroked-button (click)="onBuildOffer(numericAnnouncementHex)">New Numeric</button>
   </div>
 
   <div class="paste-input">

--- a/wallet-server-ui/src/app/component/build-accept-offer/build-accept-offer.component.html
+++ b/wallet-server-ui/src/app/component/build-accept-offer/build-accept-offer.component.html
@@ -10,8 +10,12 @@
   </div>
 
   <div hidden>
-    <button mat-stroked-button (click)="onBuildOffer(enumAnnouncementHex)">New Enum</button>
-    <button mat-stroked-button (click)="onBuildOffer(numericAnnouncementHex)">New Numeric</button>
+    <label>Enum</label>
+    <button mat-stroked-button (click)="onBuildOffer(enumAnnouncementHex)">A</button>
+    <button mat-stroked-button (click)="onBuildOffer(enumContractInfoHex)">CI</button>
+    <label>Numeric</label>
+    <button mat-stroked-button (click)="onBuildOffer(numericAnnouncementHex)">A</button>
+    <button mat-stroked-button (click)="onBuildOffer(numericContractInfoHex)">CI</button>
   </div>
 
   <div class="paste-input">

--- a/wallet-server-ui/src/app/component/build-accept-offer/build-accept-offer.component.html
+++ b/wallet-server-ui/src/app/component/build-accept-offer/build-accept-offer.component.html
@@ -24,9 +24,9 @@
       (paste)="onAcceptOfferPaste($event)" (input)="onAcceptOfferInput($event)">
   </div>
 
-  <div hidden>
+  <!-- <div hidden>
     <button mat-stroked-button (click)="onNewEnum()">New Enum Contract</button>
     <button mat-stroked-button (click)="onNewNumeric()">New Numeric Contract</button>
-  </div>
+  </div> -->
 
 </section>

--- a/wallet-server-ui/src/app/component/build-accept-offer/build-accept-offer.component.html
+++ b/wallet-server-ui/src/app/component/build-accept-offer/build-accept-offer.component.html
@@ -9,7 +9,7 @@
       (paste)="onBuildOfferPaste($event)" (input)="onBuildOfferInput($event)">
   </div>
 
-  <div>
+  <div hidden>
     <button mat-stroked-button (click)="onBuildOffer(enumAnnouncementHex)">New Enum</button>
     <button mat-stroked-button (click)="onBuildOffer(numericAnnouncementHex)">New Numeric</button>
   </div>

--- a/wallet-server-ui/src/app/component/build-accept-offer/build-accept-offer.component.ts
+++ b/wallet-server-ui/src/app/component/build-accept-offer/build-accept-offer.component.ts
@@ -149,67 +149,67 @@ export class BuildAcceptOfferComponent implements OnInit {
 
   // Static new Contract functions
 
-  onNewEnum() {
-    console.debug('onNewEnum()')
+  // onNewEnum() {
+  //   console.debug('onNewEnum()')
 
-    // Data : https://test.oracle.suredbits.com/announcement/63fa7885e3c6052e97956961698cde2b286dc1621544bbd8fcfbd78b2b1dbdcf
-    const enumAnnouncementHex = 'fdd824a8823cf7a3e449260f46d3d9a5bb0ddf1a367e0d3c9ce8858e16cd783392560bd1c9671314d54b6cb258bc6d85ab8fe238a27feb5a27d75323524a54d712a80b70a305b66d790ea4afe15b3fb61cae4d77f050e57b41f10f530c48a23dddbe335afdd822440001c3b0ecdaeaa3bbbd53386dec623b3a884b0ca2e2777cc62f0b6f891d9226114d614ebae0fdd80611000205546f64617908546f6d6f72726f7708546f6d6f72726f77'
-    const totalCollateral = 200003
-    const payoutVals = { outcomes: { 'Today': 200003, 'Tomorrow': 0 } }
+  //   // Data : https://test.oracle.suredbits.com/announcement/63fa7885e3c6052e97956961698cde2b286dc1621544bbd8fcfbd78b2b1dbdcf
+  //   const enumAnnouncementHex = 'fdd824a8823cf7a3e449260f46d3d9a5bb0ddf1a367e0d3c9ce8858e16cd783392560bd1c9671314d54b6cb258bc6d85ab8fe238a27feb5a27d75323524a54d712a80b70a305b66d790ea4afe15b3fb61cae4d77f050e57b41f10f530c48a23dddbe335afdd822440001c3b0ecdaeaa3bbbd53386dec623b3a884b0ca2e2777cc62f0b6f891d9226114d614ebae0fdd80611000205546f64617908546f6d6f72726f7708546f6d6f72726f77'
+  //   const totalCollateral = 200003
+  //   const payoutVals = { outcomes: { 'Today': 200003, 'Tomorrow': 0 } }
     
-    this.messageService.sendMessage(getMessageBody(DLCMessageType.createcontractinfo, 
-      [enumAnnouncementHex, totalCollateral, payoutVals])).subscribe(r => {
-        console.debug('createcontractinfo', r)
+  //   this.messageService.sendMessage(getMessageBody(DLCMessageType.createcontractinfo, 
+  //     [enumAnnouncementHex, totalCollateral, payoutVals])).subscribe(r => {
+  //       console.debug('createcontractinfo', r)
 
-        if (r.result) {
-          const contractInfoTLV = <string>r.result
-          const collateral = 100002
-          const feeRate = 1
-          const now = new Date()
-          // ERROR IS HERE - The server is unhappy with this secondsSinceEpoch
-          const secondsSinceEpoch = Math.round(now.getTime() / 1000)
-          const locktime = secondsSinceEpoch
-          const refundLT = secondsSinceEpoch + 1000000
-          this.messageService.sendMessage(getMessageBody(WalletMessageType.createdlcoffer, 
-            [contractInfoTLV, collateral, feeRate, locktime, refundLT])).subscribe(r => {
-            console.warn('CreateDLCOffer()', r)
-            if (r.result) {
-              this.walletStateService.refreshDLCStates()
-            }
-          })
-        }
-      })
-  }
+  //       if (r.result) {
+  //         const contractInfoTLV = <string>r.result
+  //         const collateral = 100002
+  //         const feeRate = 1
+  //         const now = new Date()
+  //         // ERROR IS HERE - The server is unhappy with this secondsSinceEpoch
+  //         const secondsSinceEpoch = Math.round(now.getTime() / 1000)
+  //         const locktime = secondsSinceEpoch
+  //         const refundLT = secondsSinceEpoch + 1000000
+  //         this.messageService.sendMessage(getMessageBody(WalletMessageType.createdlcoffer, 
+  //           [contractInfoTLV, collateral, feeRate, locktime, refundLT])).subscribe(r => {
+  //           console.warn('CreateDLCOffer()', r)
+  //           if (r.result) {
+  //             this.walletStateService.refreshDLCStates()
+  //           }
+  //         })
+  //       }
+  //     })
+  // }
 
-  onNewNumeric() {
-    console.debug('onNewNumeric()')
+  // onNewNumeric() {
+  //   console.debug('onNewNumeric()')
 
-    // Data : https://test.oracle.suredbits.com/announcement/b4663b7a3aa43d228f350b74f8bbe30a96c9aaf344f8f7589e713863d419f3a2
-    const numericAnnouncementHex = 'fdd824fd016beb851d39afa08cc3d3445ee2696c105f3717bb087346acb95a77dacb9aba17f5f944e6ea8db22f926b7dfd17a306ab927f51b7b26b92c9f9cca4e83d28fb7861a305b66d790ea4afe15b3fb61cae4d77f050e57b41f10f530c48a23dddbe335afdd822fd01050007a5a92a821927337b40a30e152052482f894ff8ecfe3f5a1aa4aa3b6720bf7a2d61d7b210ecd7217d4d342c5e78a99360f920876e461fea671950622ec6a23b9d1c04bc48c6332bfe089fac15b600721f3120cc8d721ba387b59385cef7ea788e7e1cf1bc6cb8d45cf594e7af811bed009c1899439c58a82527684d50b9ed150c1127a45a7e2c93edeb9307e1c2daac7cf6658a488b7159e29e551b9dac141f42e9f41989a0e2bd4064ecf8a09d81285504ae2ec425ff2ab98feb975b4e7e64e70e4e4016a857044d634af12f361f264272a526c08fa39d2116d9136ef00024d870dbd880fdd80a0e00020004556e69740000000000070c6e756d657269634576656e74'
-    const totalCollateral = 200003
-    const numericPayoutVals = [{ outcome: 0, payout: 0, isEndpoint: true, extraPrecision: 0 }, { outcome: 127, payout: totalCollateral, isEndpoint: true, extraPrecision: 0 }]
-    console.debug('numericAnnouncementHex:', numericAnnouncementHex, 'totalCollateral:', totalCollateral, 'numericPayoutVals:', numericPayoutVals)
-    this.messageService.sendMessage(getMessageBody(DLCMessageType.createcontractinfo, 
-      [numericAnnouncementHex, totalCollateral, numericPayoutVals])).subscribe(r => {
-      console.warn('createcontractinfo', r)
+  //   // Data : https://test.oracle.suredbits.com/announcement/b4663b7a3aa43d228f350b74f8bbe30a96c9aaf344f8f7589e713863d419f3a2
+  //   const numericAnnouncementHex = 'fdd824fd016beb851d39afa08cc3d3445ee2696c105f3717bb087346acb95a77dacb9aba17f5f944e6ea8db22f926b7dfd17a306ab927f51b7b26b92c9f9cca4e83d28fb7861a305b66d790ea4afe15b3fb61cae4d77f050e57b41f10f530c48a23dddbe335afdd822fd01050007a5a92a821927337b40a30e152052482f894ff8ecfe3f5a1aa4aa3b6720bf7a2d61d7b210ecd7217d4d342c5e78a99360f920876e461fea671950622ec6a23b9d1c04bc48c6332bfe089fac15b600721f3120cc8d721ba387b59385cef7ea788e7e1cf1bc6cb8d45cf594e7af811bed009c1899439c58a82527684d50b9ed150c1127a45a7e2c93edeb9307e1c2daac7cf6658a488b7159e29e551b9dac141f42e9f41989a0e2bd4064ecf8a09d81285504ae2ec425ff2ab98feb975b4e7e64e70e4e4016a857044d634af12f361f264272a526c08fa39d2116d9136ef00024d870dbd880fdd80a0e00020004556e69740000000000070c6e756d657269634576656e74'
+  //   const totalCollateral = 200003
+  //   const numericPayoutVals = [{ outcome: 0, payout: 0, isEndpoint: true, extraPrecision: 0 }, { outcome: 127, payout: totalCollateral, isEndpoint: true, extraPrecision: 0 }]
+  //   console.debug('numericAnnouncementHex:', numericAnnouncementHex, 'totalCollateral:', totalCollateral, 'numericPayoutVals:', numericPayoutVals)
+  //   this.messageService.sendMessage(getMessageBody(DLCMessageType.createcontractinfo, 
+  //     [numericAnnouncementHex, totalCollateral, numericPayoutVals])).subscribe(r => {
+  //     console.warn('createcontractinfo', r)
 
-      if (!(typeof r === 'string')) { // !== 'failure') {
-        const contractInfoTLV = <string>r.result
-        const collateral = 100000
-        const feeRate = 1
-        const now = new Date()
-        const secondsSinceEpoch = Math.round(now.getTime() / 1000) // dateToSecondsSinceEpoch(new Date())
-        const locktime = secondsSinceEpoch
-        const refundLT = secondsSinceEpoch + 1000000
-        this.messageService.sendMessage(getMessageBody(WalletMessageType.createdlcoffer, 
-          [contractInfoTLV, collateral, feeRate, locktime, refundLT])).subscribe(r => {
-          console.warn('CreateDLCOffer()', r)
-          if (r.result) {
-            this.walletStateService.refreshDLCStates()
-          }
-        })
-      }
+  //     if (!(typeof r === 'string')) { // !== 'failure') {
+  //       const contractInfoTLV = <string>r.result
+  //       const collateral = 100000
+  //       const feeRate = 1
+  //       const now = new Date()
+  //       const secondsSinceEpoch = Math.round(now.getTime() / 1000) // dateToSecondsSinceEpoch(new Date())
+  //       const locktime = secondsSinceEpoch
+  //       const refundLT = secondsSinceEpoch + 1000000
+  //       this.messageService.sendMessage(getMessageBody(WalletMessageType.createdlcoffer, 
+  //         [contractInfoTLV, collateral, feeRate, locktime, refundLT])).subscribe(r => {
+  //         console.warn('CreateDLCOffer()', r)
+  //         if (r.result) {
+  //           this.walletStateService.refreshDLCStates()
+  //         }
+  //       })
+  //     }
       
-    })
-  }
+  //   })
+  // }
 }

--- a/wallet-server-ui/src/app/component/build-accept-offer/build-accept-offer.component.ts
+++ b/wallet-server-ui/src/app/component/build-accept-offer/build-accept-offer.component.ts
@@ -1,4 +1,6 @@
 import { Component, ElementRef, EventEmitter, OnInit, Output, ViewChild } from '@angular/core'
+import { Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 import { MessageService } from '~service/message.service'
 import { WalletStateService } from '~service/wallet-state-service';
@@ -19,15 +21,18 @@ export class BuildAcceptOfferComponent implements OnInit {
 
   @Output() announcement: EventEmitter<AnnouncementWithHex> = new EventEmitter<AnnouncementWithHex>()
   @Output() contractInfo: EventEmitter<ContractInfoWithHex> = new EventEmitter<ContractInfoWithHex>()
-  @Output() offer: EventEmitter<OfferWithHex> = new EventEmitter<OfferWithHex>()
 
   @Output() acceptOffer: EventEmitter<OfferWithHex> = new EventEmitter<OfferWithHex>()
 
-
-  // Data : https://test.oracle.suredbits.com/announcement/63fa7885e3c6052e97956961698cde2b286dc1621544bbd8fcfbd78b2b1dbdcf
+  // Testing Data
+  // https://test.oracle.suredbits.com/announcement/63fa7885e3c6052e97956961698cde2b286dc1621544bbd8fcfbd78b2b1dbdcf
   enumAnnouncementHex = 'fdd824a8823cf7a3e449260f46d3d9a5bb0ddf1a367e0d3c9ce8858e16cd783392560bd1c9671314d54b6cb258bc6d85ab8fe238a27feb5a27d75323524a54d712a80b70a305b66d790ea4afe15b3fb61cae4d77f050e57b41f10f530c48a23dddbe335afdd822440001c3b0ecdaeaa3bbbd53386dec623b3a884b0ca2e2777cc62f0b6f891d9226114d614ebae0fdd80611000205546f64617908546f6d6f72726f7708546f6d6f72726f77'
-  // Data : https://test.oracle.suredbits.com/announcement/b4663b7a3aa43d228f350b74f8bbe30a96c9aaf344f8f7589e713863d419f3a2
+  // https://test.oracle.suredbits.com/announcement/b4663b7a3aa43d228f350b74f8bbe30a96c9aaf344f8f7589e713863d419f3a2
   numericAnnouncementHex = 'fdd824fd016beb851d39afa08cc3d3445ee2696c105f3717bb087346acb95a77dacb9aba17f5f944e6ea8db22f926b7dfd17a306ab927f51b7b26b92c9f9cca4e83d28fb7861a305b66d790ea4afe15b3fb61cae4d77f050e57b41f10f530c48a23dddbe335afdd822fd01050007a5a92a821927337b40a30e152052482f894ff8ecfe3f5a1aa4aa3b6720bf7a2d61d7b210ecd7217d4d342c5e78a99360f920876e461fea671950622ec6a23b9d1c04bc48c6332bfe089fac15b600721f3120cc8d721ba387b59385cef7ea788e7e1cf1bc6cb8d45cf594e7af811bed009c1899439c58a82527684d50b9ed150c1127a45a7e2c93edeb9307e1c2daac7cf6658a488b7159e29e551b9dac141f42e9f41989a0e2bd4064ecf8a09d81285504ae2ec425ff2ab98feb975b4e7e64e70e4e4016a857044d634af12f361f264272a526c08fa39d2116d9136ef00024d870dbd880fdd80a0e00020004556e69740000000000070c6e756d657269634576656e74'
+  // https://test.oracle.suredbits.com/contract/enum/ff565f1d3abcc83bc3c470c783c37b31ff0fe5552bb6bd5b176d651b4250a7af
+  enumContractInfoHex = 'fdd82ef400000000000186a0fda71018020359455300000000000186a0024e4f0000000000000000fda712ccfdd824c81d9f316ca49f7dba3544eb8aa4db9d7d3d2f5590352cd0eb2bf8bac70877d2e35862a9cb8112dab3234665c80bb99002fa87ea027cc7cd4d96cbd082ad23569e5d1bcfab252c6dd9edd7aea4c5eeeef138f7ff7346061ea40143a9f5ae80baa9fdd8226400011ba97f848d290edf97a4bdeedbb9df2b963c2690ed0099c00bceb4c2ceb7ca6760835170fdd80609000203594553024e4f30436f696e62617365204254432f555344203e3d202435312c30303020323032312d30342d32335432333a30303a30305a'
+  // https://test.oracle.suredbits.com/contract/numeric/fd77c10613f25566c9aa9da72e4f02d1271a4cd0d9287ac461a21f50464232e6
+  numericContractInfoHex = 'fdd82efd034100000000000186a0fda720540012fda72648000501000000000000000000000001fd753000000000000061a8000001fd88b8000000000000c350000001fd9c4000000000000186a0000001fe0003ffff00000000000186a00000fda724020000fda712fd02dbfdd824fd02d527bd1f768121a074176a1986e2cacd46e6cd992a7b3d5ac3827a3f90b5f12d0753ec47c521966aae316c65a4350e22207ae47286d343de866f19f5eeb7de13815d1bcfab252c6dd9edd7aea4c5eeeef138f7ff7346061ea40143a9f5ae80baa9fdd822fd026f001296d22911c0abd9f2736a45ce0fac39ccd7ded8cbd7a88d160c86e66c37d698a5934f30404cf929aa1f3fe40a04c3c952ca8c6b239c01c9b61676fb7590876b015811222090ee7015017617f468ed05d567e511d9d76d5d115dee863e5f43f8654509a3f2643971573e74f5c5bf5b9d482768a50726383c784af741ae4f59b61ab80d24f5b25dc4c826fd4275715b047dc55b23814d2b81539fcbcd536bd858b0cab6b1a6e7050943a0ee3e01ea005abf62abbd28f8c07362c53d6c187d8eb88dd9b4fd15aad3c3b2271c62bfa8eef0504912164a0f16ca931d59e3dc63d3d92eae714f2abe0f9a0d215357845b3137bf8c96fac0726c82735a23a3baa656229fdcca56ca502cb1623a985e1f6be919c7cfe11155ebf802d4544d4dfc7b354f644e3fb99088aef2c0d71916178c9f3695089e85edfe27044a9cf1a7b821a2a239a196682a0a35ad1a2f60f0f888aa51e4a0a44523592996de3f7f93af6c587f6252b850c562e1bfb97e0a8ee1406ae0c129d34b42a2d8a44597a0147c5cc0dc192beb614664e9b1949f1d95b4ae92ec85617e93b1fb6991b994df3b26ca21aacc908ed102de9988c55cf3a3a70c87e4067ae7648efd6763cd6655ce2c98b5b298ca7eb94fefaf53f58fdd3cbd486da3d79e651dfd392dccf2bd60dfbc708ca171587cda472646709ee6d51650eb2a808796ffd709b041c00afe0e028530f7bb888d90dff6ec6902108e1ec5a1bd1ba33515fdfe1bdb49bd3dfa576de14f83e51ac53a2f72fe6556576ee76cbbfc1e5f09c7ad076fd7ca847962c87dce96dd496d6062da80fdd80a11000200074254432d55534400000000001213446572696269742d4254432d33304d41523231'
 
   constructor(private messageService: MessageService, private walletStateService: WalletStateService) { }
 
@@ -39,17 +44,18 @@ export class BuildAcceptOfferComponent implements OnInit {
     const clipboardData = event.clipboardData
     if (clipboardData) {
       const trimmedPastedText = clipboardData.getData('text').trim()
-      console.debug('trimmedPastedText:', trimmedPastedText)
+      // console.debug('trimmedPastedText:', trimmedPastedText)
 
       // Sanity check on pastedText first?
 
       this.onBuildOffer(trimmedPastedText)
     }
-    
   }
 
   onBuildOfferInput(event: Event) {
-    console.debug('onBuildOfferInput()', event)
+    // console.debug('onBuildOfferInput()', event)
+    // Not supporting editing in the field for now
+    return
     const text = this.buildOfferInput.nativeElement.value
     this.onBuildOffer(text)
   }
@@ -57,38 +63,44 @@ export class BuildAcceptOfferComponent implements OnInit {
   onBuildOffer(hex: string) {
     console.debug('onBuildOffer()', hex)
     if (hex) {
-
-      // Need to suppress error handling so any of these calls can fail gracefully
-
-      this.messageService.sendMessage(getMessageBody(CoreMessageType.decodeannouncement, [hex])).subscribe(r => {
+      // Suppressing error handling so any of these calls can fail gracefully
+      this.messageService.sendMessage(getMessageBody(CoreMessageType.decodeannouncement, [hex]), false).pipe(catchError((error: any) => {
+        console.debug('failed to decode announcement')
+        // Try another
+        this.messageService.sendMessage(getMessageBody(CoreMessageType.decodecontractinfo, [hex]), false).pipe(catchError((error: any) => {
+          console.debug('failed to decode contract info')
+          // TODO : Tell user nothing was matched
+          // Try another
+          // this.messageService.sendMessage(getMessageBody(CoreMessageType.decodeoffer, [hex]), false).pipe(catchError((error: any) => {
+          //   console.debug('failed to decode offer')
+          //   // TODO : Tell user nothing was matched
+          //   return new Observable<any>()
+          // })).subscribe(r => {
+          //   console.debug('decodeoffer', r)
+          //   if (r.result) {
+          //     const offer = <OfferWithHex>{ offer: r.result, hex }
+          //     this.offer.next(offer)
+          //     this.clearBuildOfferInput()
+          //   } else {
+          //     // No more to try
+          //   }
+          // })
+          return new Observable<any>()
+        })).subscribe(r => {
+          console.debug('decodecontractinfo', r)
+          if (r.result) {
+            const contractInfo = <ContractInfoWithHex>{ contractInfo: r.result, hex }
+            this.contractInfo.next(contractInfo)
+            this.clearBuildOfferInput()
+          }
+        })
+        return new Observable<any>()
+      })).subscribe(r => {
         console.debug('decodeannouncement', r)
-
         if (r.result) {
           const announcementWithHex = <AnnouncementWithHex>{ announcement: r.result, hex }
           this.announcement.next(announcementWithHex)
           this.clearBuildOfferInput()
-        } else {
-          // Try another
-          this.messageService.sendMessage(getMessageBody(CoreMessageType.decodecontractinfo, [hex])).subscribe(r => {
-            console.debug('decodecontractinfo', r)
-
-            if (r.result) {
-              const contractInfo = <ContractInfoWithHex>{ contractInfo: r.result, hex }
-              this.contractInfo.next(contractInfo)
-            } else {
-              // Try another
-              this.messageService.sendMessage(getMessageBody(CoreMessageType.decodeoffer, [hex])).subscribe(r => {
-                console.debug('decodeoffer', r)
-
-                if (r.result) {
-                  const offer = <OfferWithHex>{ offer: r.result, hex }
-                  this.offer.next(offer)
-                } else {
-                  // No more to try
-                }
-              })
-            }
-          })
         }
       })
     }
@@ -103,7 +115,7 @@ export class BuildAcceptOfferComponent implements OnInit {
     const clipboardData = event.clipboardData
     if (clipboardData) {
       const trimmedPastedText = clipboardData.getData('text').trim()
-      console.debug('patrimmedPastedTexttedText:', trimmedPastedText)
+      // console.debug('trimmedPastedTexttedText:', trimmedPastedText)
       this.onAcceptOffer(trimmedPastedText)
     }
   }

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -2,63 +2,114 @@
   <div class="section-header">
     <h2 translate>contractDetail.heading</h2>
     <!-- <button mat-icon-button class="close-button" (click)="onClose()"><mat-icon>close</mat-icon></button> -->
+    <button mat-icon-button matTooltip="{{ 'action.reload' | translate }}" (click)="onReloadContract()">
+      <mat-icon>refresh</mat-icon>
+    </button>
   </div>
 
   <div *ngIf="dlc && contractInfo">
     <div class="field-group">
       <label translate>contractDetail.eventId</label>
-      <input [value]="contractInfo.oracleInfo.announcement.event.eventId" disabled>
-    </div>
-    <div class="field-group">
-      <label translate>contractDetail.dlcId</label>
-      <input [value]="dlc.dlcId" disabled>
-    </div>
-    
-    <div class="spacer"></div>
-    
-    <div class="field-group">
-      <label translate>contractDetail.initiator</label>
-      <input [value]="dlc.isInitiator" disabled>
+      <input class="event-id-input" [value]="contractInfo.oracleInfo.announcement.event.eventId" disabled>
     </div>
     <div class="field-group">
       <label translate>contractDetail.state</label>
       <input [value]="dlc.state" disabled>
     </div>
     <div class="field-group">
-      <label translate>contractDetail.contractId</label>
-      <input [value]="dlc.contractId ? dlc.contractId : ''" disabled>
+      <label translate>contractDetail.initiator</label>
+      <input [value]="dlc.isInitiator" disabled>
     </div>
+    
+    <div class="spacer"></div>
+
     <div class="field-group">
-      <label translate>contractDetail.contractInfo</label>
-      <input [value]="dlc.contractInfo" disabled>
+      <label translate>contractDetail.contractTimeout</label>
+      <input [(ngModel)]="contractTimeout" disabled>
     </div>
     <div class="field-group">
       <label translate>contractDetail.feeRate</label>
       <input [value]="dlc.feeRate" disabled>
       <span translate>unit.satsPerVbyte</span>
     </div>
-    <div class="field-group">
-      <label translate>contractDetail.contractTimeout</label>
-      <input [(ngModel)]="contractTimeout" disabled>
-    </div>
+
+    <div class="spacer"></div>
+
+    <label class="group-label" translate>contractDetail.collateral</label>
     <div class="field-group">
       <label translate>contractDetail.totalCollateral</label>
       <input [value]="dlc.totalCollateral" disabled>
       <span translate>unit.sats</span>
     </div>
+    <div class="field-group">
+      <label translate>contractDetail.localCollateral</label>
+      <input [value]="dlc.localCollateral" disabled>
+      <span translate>unit.sats</span>
+    </div>
+    <div class="field-group">
+      <label translate>contractDetail.remoteCollateral</label>
+      <input [value]="dlc.remoteCollateral" disabled>
+      <span translate>unit.sats</span>
+    </div>
 
     <div class="spacer"></div>
 
+    <div *ngIf="dlc.myPayout !== undefined && dlc.pnl !== undefined && dlc.rateOfReturn !== undefined" class="payout-group">
+      <label class="group-label" translate>contractDetail.contractOutcome</label>
+      <div class="field-group">
+        <label translate>contractDetail.myPayout</label>
+        <input [value]="dlc.myPayout" disabled>
+        <span translate>unit.sats</span>
+      </div>
+      <div class="field-group">
+        <label translate>contractDetail.counterpartyPayout</label>
+        <input [value]="dlc.counterPartyPayout" disabled>
+        <span translate>unit.sats</span>
+      </div>
+      <div class="field-group">
+        <label translate>contractDetail.pnl</label>
+        <input [value]="dlc.pnl" disabled>
+        <span translate>unit.sats</span>
+      </div>
+      <div class="field-group">
+        <label translate>contractDetail.rateOfReturn</label>
+        <input [value]="formatPercent(dlc.rateOfReturn)" disabled>
+        <span translate>unit.percent</span>
+      </div>
+
+      <div class="spacer"></div>
+    </div>
+
     <div *ngIf="isEnum()" class="enum-outcomes">
-      <label translate>{{ 'contractDetail.outcomePayouts' | translate }}</label>
+      <label class="group-label" translate>contractDetail.outcomePayouts</label>
       <div *ngFor="let l of Object.keys(getEnumContractDescriptor().outcomes)" class="enum-group">
         <label>{{ l }}</label>
         <input [value]="getOutcomeValue( getEnumContractDescriptor().outcomes[l] )" disabled>
         <span translate>unit.sats</span>
       </div>
+
+      <div class="spacer"></div>
     </div>
 
+    <!-- TODO : Enum Outcome -->
+
     <!-- TODO : Payout curve -->
+
+    <div class="field-group">
+      <label translate>contractDetail.dlcId</label>
+      <input [value]="dlc.dlcId" disabled>
+    </div>
+    <div class="field-group">
+      <label translate>contractDetail.contractId</label>
+      <input [value]="dlc.contractId ? dlc.contractId : ''" disabled>
+      <button mat-icon-button class="copy-button" [disabled]= "!dlc.contractId"
+        matTooltip="{{ 'action.copyToClipboard' | translate }}"
+        (click)="onCopyContractId()"><mat-icon>content_copy</mat-icon></button>
+    </div>
+    <div class="field-group">
+      <label translate>contractDetail.contractInfo</label>
+      <input [value]="dlc.contractInfo" disabled>
+    </div>
 
     <div class="spacer"></div>
 
@@ -85,6 +136,8 @@
     </div>
   </div>
 
+  <div class="spacer"></div>
+
   <div class="button-group">
     <button mat-stroked-button color="warn" (click)="onCancelContract()" [disabled]="!isCancelable(dlc.state)">
       {{ 'contractDetail.cancelContract' | translate }}
@@ -92,8 +145,8 @@
     <button mat-stroked-button color="warn" (click)="onRefund()" [disabled]="!isRefundable(dlc.state)">
       {{ 'contractDetail.refundContract' | translate }}
     </button>
-    <button mat-icon-button matTooltip="{{ 'action.reload' | translate }}" (click)="onReloadContract()">
-      <mat-icon>refresh</mat-icon>
+    <button mat-stroked-button (click)="onViewOnOracleExplorer()" disabled>
+      {{ 'contractDetail.viewOnOracleExplorer' | translate }}
     </button>
   </div>
 

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -1,10 +1,14 @@
 <section class="contract-detail">
   <div class="section-header">
     <h2 translate>contractDetail.heading</h2>
-    <!-- <button mat-icon-button class="close-button" (click)="onClose()"><mat-icon>close</mat-icon></button> -->
-    <button mat-icon-button matTooltip="{{ 'action.reload' | translate }}" (click)="onReloadContract()">
-      <mat-icon>refresh</mat-icon>
-    </button>
+    <div class="section-header-button-group">
+      <button mat-icon-button matTooltip="{{ 'action.reload' | translate }}" (click)="onReloadContract()">
+        <mat-icon>refresh</mat-icon>
+      </button>
+      <button mat-icon-button class="close-button" matTooltip="{{ 'action.close' | translate }}" (click)="onClose()">
+        <mat-icon>close</mat-icon>
+      </button>
+    </div>
   </div>
 
   <div *ngIf="dlc && contractInfo">

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -13,6 +13,7 @@
       <label translate>contractDetail.eventId</label>
       <input [value]="contractInfo.oracleInfo.announcement.event.eventId" disabled>
     </div>
+    <div class="spacer"></div>
     <div class="field-group">
       <label translate>contractDetail.initiator</label>
       <input [value]="dlc.isInitiator" disabled>
@@ -41,6 +42,21 @@
       <label translate>contractDetail.totalCollateral</label>
       <input [value]="dlc.totalCollateral" disabled>
     </div>
+
+    <div class="spacer"></div>
+
+    <div *ngIf="isEnum()" class="enum-outcomes">
+      <label translate>{{ 'contractDetail.outcomePayouts' | translate }}</label>
+      <div *ngFor="let l of Object.keys(getEnumContractDescriptor().outcomes)" class="enum-group">
+        <label>{{ l }}</label>
+        <input [value]="getOutcomeValue( getEnumContractDescriptor().outcomes[l] )" disabled>
+      </div>
+    </div>
+
+    <!-- TODO : Payout curve -->
+
+    <div class="spacer"></div>
+
     <div class="field-group">
       <label translate>contractDetail.fundingTransactionId</label>
       <input [value]="dlc.fundingTxId ? dlc.fundingTxId : ''" disabled>

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -6,14 +6,16 @@
 
   <div *ngIf="dlc && contractInfo">
     <div class="field-group">
-      <label translate>contractDetail.dlcId</label>
-      <input [value]="dlc.dlcId" disabled>
-    </div>
-    <div class="field-group">
       <label translate>contractDetail.eventId</label>
       <input [value]="contractInfo.oracleInfo.announcement.event.eventId" disabled>
     </div>
+    <div class="field-group">
+      <label translate>contractDetail.dlcId</label>
+      <input [value]="dlc.dlcId" disabled>
+    </div>
+    
     <div class="spacer"></div>
+    
     <div class="field-group">
       <label translate>contractDetail.initiator</label>
       <input [value]="dlc.isInitiator" disabled>
@@ -33,6 +35,7 @@
     <div class="field-group">
       <label translate>contractDetail.feeRate</label>
       <input [value]="dlc.feeRate" disabled>
+      <span translate>unit.satsPerVbyte</span>
     </div>
     <div class="field-group">
       <label translate>contractDetail.contractTimeout</label>
@@ -41,6 +44,7 @@
     <div class="field-group">
       <label translate>contractDetail.totalCollateral</label>
       <input [value]="dlc.totalCollateral" disabled>
+      <span translate>unit.sats</span>
     </div>
 
     <div class="spacer"></div>
@@ -50,6 +54,7 @@
       <div *ngFor="let l of Object.keys(getEnumContractDescriptor().outcomes)" class="enum-group">
         <label>{{ l }}</label>
         <input [value]="getOutcomeValue( getEnumContractDescriptor().outcomes[l] )" disabled>
+        <span translate>unit.sats</span>
       </div>
     </div>
 

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -23,7 +23,7 @@
     </div>
     <div class="field-group">
       <label translate>contractDetail.contractId</label>
-      <input [value]="" disabled>
+      <input [value]="dlc.contractId ? dlc.contractId : ''" disabled>
     </div>
     <div class="field-group">
       <label translate>contractDetail.contractInfo</label>
@@ -44,34 +44,37 @@
     <div class="field-group">
       <label translate>contractDetail.fundingTransactionId</label>
       <input [value]="dlc.fundingTxId ? dlc.fundingTxId : ''" disabled>
-      <button mat-stroked-button (click)="onRebroadcastFundingTransaction()" disabled>{{ 'contractDetail.rebroadcast' | translate }}</button>
+      <button mat-stroked-button (click)="onRebroadcastFundingTransaction()" [disabled]="dlc.state !== DLCState.broadcast">
+        {{ 'contractDetail.rebroadcast' | translate }}
+      </button>
     </div>
     <div class="field-group">
       <label translate>contractDetail.closingTransactionId</label>
-      <input [value]="" disabled>
-      <button mat-stroked-button (click)="onRebroadcastClosingTransaction()" disabled>{{ 'contractDetail.rebroadcast' | translate }}</button>
+      <input [value]="dlc.closingTxId ? dlc.closingTxId : ''" disabled>
+      <button mat-stroked-button (click)="onRebroadcastClosingTransaction()" [disabled]="!dlc.closingTxId">
+        {{ 'contractDetail.rebroadcast' | translate }}
+      </button>
     </div>
     <div class="field-group">
       <label translate>contractDetail.oracleSignatures</label>
-      <button mat-stroked-button (click)="onOracleSignatures()" disabled>{{ 'action.execute' | translate }}</button>
+      <input [(ngModel)]="oracleSignature" [disabled]="!dlc.contractId || dlc.state !== DLCState.broadcast">
+      <button mat-stroked-button (click)="onOracleSignatures()" [disabled]="!dlc.contractId || !oracleSignature">
+        {{ 'action.execute' | translate }}
+      </button>
     </div>
   </div>
 
-  <div>
-    <!-- TODO : Graph -->
+  <div class="button-group">
+    <button mat-icon-button matTooltip="{{ 'action.reload' | translate }}" (click)="onReloadContract()">
+      <mat-icon>refresh</mat-icon>
+    </button>
+    <button mat-stroked-button color="warn" (click)="onCancelContract()" [disabled]="!isCancelable(dlc.state)">
+      {{ 'contractDetail.cancelContract' | translate }}
+    </button>
+    <button mat-stroked-button color="warn" (click)="onRefund()" [disabled]="!isRefundable(dlc.state)">
+      {{ 'contractDetail.refundContract' | translate }}
+    </button>
   </div>
-
-  <!--
-  <div>
-    {{ dlc | json }}
-  </div>
-
-  <div>
-    {{ contractInfo | json }}
-  </div>
-  -->
-
-  <button mat-stroked-button color="warn" (click)="onCancelContract()">{{ 'contractDetail.cancelContract' | translate }}</button>
 
   <!-- <app-alert *ngIf="showDeleteSuccess" [type]="AlertType.success" message="Contract Deleted"></app-alert> -->
 

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -43,7 +43,7 @@
     </div>
     <div class="field-group">
       <label translate>contractDetail.fundingTransactionId</label>
-      <input [value]="" disabled>
+      <input [value]="dlc.fundingTxId ? dlc.fundingTxId : ''" disabled>
       <button mat-stroked-button (click)="onRebroadcastFundingTransaction()" disabled>{{ 'contractDetail.rebroadcast' | translate }}</button>
     </div>
     <div class="field-group">
@@ -71,7 +71,7 @@
   </div>
   -->
 
-  <button mat-stroked-button color="warn" (click)="onCancelContract()" hidden>{{ 'contractDetail.cancelContract' | translate }}</button>
+  <button mat-stroked-button color="warn" (click)="onCancelContract()">{{ 'contractDetail.cancelContract' | translate }}</button>
 
   <!-- <app-alert *ngIf="showDeleteSuccess" [type]="AlertType.success" message="Contract Deleted"></app-alert> -->
 

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -35,7 +35,7 @@
     </div>
     <div class="field-group">
       <label translate>contractDetail.contractTimeout</label>
-      <input [value]="dlc.contractTimeout" disabled>
+      <input [(ngModel)]="contractTimeout" disabled>
     </div>
     <div class="field-group">
       <label translate>contractDetail.totalCollateral</label>
@@ -44,7 +44,7 @@
     <div class="field-group">
       <label translate>contractDetail.fundingTransactionId</label>
       <input [value]="dlc.fundingTxId ? dlc.fundingTxId : ''" disabled>
-      <button mat-stroked-button (click)="onRebroadcastFundingTransaction()" [disabled]="dlc.state !== DLCState.broadcast">
+      <button mat-stroked-button (click)="onRebroadcastFundingTransaction()" [disabled]="!isFundingTxRebroadcastable(dlc.state)">
         {{ 'contractDetail.rebroadcast' | translate }}
       </button>
     </div>
@@ -57,22 +57,22 @@
     </div>
     <div class="field-group">
       <label translate>contractDetail.oracleSignatures</label>
-      <input [(ngModel)]="oracleSignature" [disabled]="!dlc.contractId || dlc.state !== DLCState.broadcast">
-      <button mat-stroked-button (click)="onOracleSignatures()" [disabled]="!dlc.contractId || !oracleSignature">
+      <input [(ngModel)]="oracleSignature" [disabled]="!isExecutable(dlc.state)">
+      <button mat-stroked-button (click)="onOracleSignatures()" [disabled]="!isExecutable(dlc.state) || !oracleSignature">
         {{ 'action.execute' | translate }}
       </button>
     </div>
   </div>
 
   <div class="button-group">
-    <button mat-icon-button matTooltip="{{ 'action.reload' | translate }}" (click)="onReloadContract()">
-      <mat-icon>refresh</mat-icon>
-    </button>
     <button mat-stroked-button color="warn" (click)="onCancelContract()" [disabled]="!isCancelable(dlc.state)">
       {{ 'contractDetail.cancelContract' | translate }}
     </button>
     <button mat-stroked-button color="warn" (click)="onRefund()" [disabled]="!isRefundable(dlc.state)">
       {{ 'contractDetail.refundContract' | translate }}
+    </button>
+    <button mat-icon-button matTooltip="{{ 'action.reload' | translate }}" (click)="onReloadContract()">
+      <mat-icon>refresh</mat-icon>
     </button>
   </div>
 

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -37,11 +37,6 @@
 
     <label class="group-label" translate>contractDetail.collateral</label>
     <div class="field-group">
-      <label translate>contractDetail.totalCollateral</label>
-      <input [value]="dlc.totalCollateral" disabled>
-      <span translate>unit.sats</span>
-    </div>
-    <div class="field-group">
       <label translate>contractDetail.localCollateral</label>
       <input [value]="dlc.localCollateral" disabled>
       <span translate>unit.sats</span>
@@ -49,6 +44,11 @@
     <div class="field-group">
       <label translate>contractDetail.remoteCollateral</label>
       <input [value]="dlc.remoteCollateral" disabled>
+      <span translate>unit.sats</span>
+    </div>
+    <div class="field-group">
+      <label translate>contractDetail.totalCollateral</label>
+      <input [value]="dlc.totalCollateral" disabled>
       <span translate>unit.sats</span>
     </div>
 

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -28,6 +28,10 @@
     <div class="spacer"></div>
 
     <div class="field-group">
+      <label translate>contractDetail.contractMaturity</label>
+      <input [(ngModel)]="contractMaturity" disabled>
+    </div>
+    <div class="field-group">
       <label translate>contractDetail.contractTimeout</label>
       <input [(ngModel)]="contractTimeout" disabled>
     </div>

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.scss
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.scss
@@ -9,6 +9,9 @@
       display: inline-block;
       width: 12rem;
     }
+    span {
+      margin-left: 0.25rem;
+    }
   }
 
   .enum-outcomes {
@@ -22,6 +25,9 @@
       input {
         display: inline-block;
         width: 6rem;
+      }
+      span {
+        margin-left: 0.25rem;
       }
     }
   }

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.scss
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.scss
@@ -14,6 +14,10 @@
     }
   }
 
+  .event-id-input {
+    width: 20rem !important;
+  }
+
   .enum-outcomes {
     .enum-group {
       margin-left: 1rem;
@@ -32,8 +36,17 @@
     }
   }
 
+  .payout-group {
+    
+  }
+
+  .group-label {
+    display: inline-block;
+    margin-bottom: 0.5rem;
+  }
+
   .spacer {
-    height: 1rem;
+    height: 1.5rem;
   }
 
   .contract-detail-grid {

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.scss
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.scss
@@ -7,7 +7,7 @@
     }
     input {
       display: inline-block;
-      width: 24rem;
+      width: 12rem;
     }
   }
 

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.scss
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.scss
@@ -11,6 +11,25 @@
     }
   }
 
+  .enum-outcomes {
+    .enum-group {
+      margin-left: 1rem;
+
+      label {
+        display: inline-block;
+        width: 12rem;
+      }
+      input {
+        display: inline-block;
+        width: 6rem;
+      }
+    }
+  }
+
+  .spacer {
+    height: 1rem;
+  }
+
   .contract-detail-grid {
     
   }

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
@@ -73,6 +73,10 @@ export class ContractDetailComponent implements OnInit {
     
   }
 
+  onClose() {
+    this.close.next()
+  }
+
   isEnum() {
     const cd = <EnumContractDescriptor><unknown>this.contractInfo.contractDescriptor
     return cd.outcomes !== undefined

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
@@ -5,7 +5,8 @@ import { TranslateService } from '@ngx-translate/core'
 import { AlertType } from '~component/alert/alert.component'
 import { MessageService } from '~service/message.service'
 import { WalletStateService } from '~service/wallet-state-service'
-import { ContractInfo, CoreMessageType, DLCContract, WalletMessageType } from '~type/wallet-server-types'
+import { Attestment, ContractInfo, CoreMessageType, DLCContract, DLCMessageType, DLCState, WalletMessageType } from '~type/wallet-server-types'
+import { isCancelable, isRefundable, validateHexString } from '~util/utils'
 import { getMessageBody } from '~util/wallet-server-util'
 
 @Component({
@@ -16,6 +17,10 @@ import { getMessageBody } from '~util/wallet-server-util'
 export class ContractDetailComponent implements OnInit {
 
   public AlertType = AlertType
+  public DLCState = DLCState
+
+  public isCancelable = isCancelable
+  public isRefundable = isRefundable
 
   _dlc!: DLCContract
   get dlc(): DLCContract { return this._dlc }
@@ -27,7 +32,9 @@ export class ContractDetailComponent implements OnInit {
 
   @Output() close: EventEmitter<void> = new EventEmitter()
 
-  showDeleteSuccess = false
+  // showDeleteSuccess = false
+
+  oracleSignature: string = ''
 
   private reset() {
 
@@ -58,17 +65,135 @@ export class ContractDetailComponent implements OnInit {
   }
 
   onOracleSignatures() {
-    console.debug('onOracleSignatures')
+    console.debug('onOracleSignatures', this.oracleSignature)
+    if (this.oracleSignature) {
+      // Keep extra whitespace out of the system
+      const os = this.oracleSignature.trim()
+      // Validate oracleSignature as hex
+      const isValidHex = validateHexString(os)
 
+      if (!isValidHex) {
+        console.error('oracleSignature is not valid hex')
+        // TODO : Dialog and 
+        return
+      }
 
+      console.debug('oracleSignature:', os, 'isValidHex:', isValidHex)
+
+      // ExecuteDLCDialog.scala:22
+      // OracleAttestmentTLV.fromHex(str.trim)
+      this.messsageService.sendMessage(getMessageBody(CoreMessageType.decodeattestments, [os])).subscribe(r => {
+        console.debug('decodeattestments', r)
+
+        if (r.result) {
+          const attestment: Attestment = r.result
+          console.debug('attestment:', attestment)
+
+          const sigs = [os] // attestment.signatures // 
+          // const contractInfoHex = this.dlc.contractInfo
+          const contractId = this.dlc.contractId
+          const noBroadcast = false // Could allow changing
+
+          // error: "requirement failed: Length specified was BigSizeUInt(169) but not enough bytes in ByteVector(62 bytes, 0x2a821927337b40a30e152052482f894ff8ecfe3f5a1aa4aa3b6720bf7a2db1cb5a846c809f79d9e8d43164b992fe18dfdecc7092ce917d48b015fef7b759)"
+
+          // Assuming attestment.signatures issue...
+
+          this.messsageService.sendMessage(getMessageBody(WalletMessageType.executedlc, 
+            [contractId, sigs, noBroadcast])).subscribe(r => {
+            console.debug('executedlc', r)
+    
+            if (r.result) { // closingTxId?
+              // This contract will change state and having closingTxId now, needs reloaded
+    
+              // Force update DLC list
+              // this.walletStateService.refreshDLCStates()
+    
+              // Update just this item?
+              this.walletStateService.refreshDLCState(this.dlc)
+            }
+          })
+        }
+      })
+    } // eo if (this.oracleSignature)
+  }
+
+  onReloadContract() {
+    console.debug('onReloadContract()')
+    this.walletStateService.refreshDLCState(this.dlc)
+  }
+
+  onRefund() {
+    console.debug('onRefund()')
+
+    const contractId = this.dlc.contractId
+    const noBroadcast = false;
+
+    this.messsageService.sendMessage(getMessageBody(WalletMessageType.executedlcrefund, [contractId, noBroadcast])).subscribe(r => {
+      console.debug('executedlcrefund', r)
+
+      if (r.result) {
+        this.walletStateService.refreshDLCState(this.dlc)
+      }
+    })
   }
 
   onRebroadcastFundingTransaction() {
     console.debug('onRebroadcastFundingTransaction()')
+
+    const contractId = this.dlc.contractId
+
+    // Request failed: Cannot broadcast the dlc when it is in the state=Confirmed contractId=Some(ByteVector(32 bytes, 0x0b528a26f38475faa95ce3738612213cf70fe35a2be0d3d67df9e8234a40f72c))
+
+    this.messsageService.sendMessage(getMessageBody(WalletMessageType.broadcastdlcfundingtx, [contractId])).subscribe(r => {
+      console.debug('broadcastdlcfundingtx', r)
+
+      if (r.result) {
+        // Show success
+        const config: any = { verticalPosition: 'top', duration: 3000 }
+        this.snackBar.open(this.translate.instant('contractDetail.fundingRebroadcastSuccess'),
+          this.translate.instant('action.dismiss'), config)
+
+        // Let polling take care of changing future state?
+      }
+    })
   }
 
   onRebroadcastClosingTransaction() {
     console.debug('onRebroadcastClosingTransaction()')
+
+    const txId = this.dlc.closingTxId
+
+    if (txId) {
+      this.messsageService.sendMessage(getMessageBody(WalletMessageType.gettransaction, [txId])).subscribe(r => {
+        // console.debug('gettransaction', r)
+
+        if (r.result) {
+          const rawTransactionHex = r.result
+
+          this.messsageService.sendMessage(getMessageBody(WalletMessageType.sendrawtransaction, [rawTransactionHex])).subscribe(r => {
+            // console.debug('sendrawtransaction', r)
+
+            if (r.result) { // closing tx id
+              // Show success
+              const config: any = { verticalPosition: 'top', duration: 3000 }
+              this.snackBar.open(this.translate.instant('contractDetail.closingRebroadcastSuccess'),
+                this.translate.instant('action.dismiss'), config)
+            }
+          })
+        }
+      })
+    }
+  }
+
+  viewOnOracleExplorer() {
+    console.debug('viewOnOracleExplorer()')
+
+    // val dlc = selectionModel.value.getSelectedItem
+    // val primaryOracle =
+    //   dlc.oracleInfo.singleOracleInfos.head.announcement
+    // val url =
+    //   GUIUtil.getAnnouncementUrl(GlobalData.network, primaryOracle)
+    // GUIUtil.openUrl(url)
   }
 
 }

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
@@ -53,11 +53,13 @@ export class ContractDetailComponent implements OnInit {
 
   // showDeleteSuccess = false
 
-  oracleSignature: string = ''
-  contractTimeout: string = ''
+  oracleSignature: string
+  contractMaturity: string
+  contractTimeout: string
 
   private reset() {
     if (this.dlc) {
+      this.contractMaturity = formatDateTime(this.dlc.contractMaturity)
       this.contractTimeout = formatDateTime(this.dlc.contractTimeout)
       this.oracleSignature = this.dlc.oracleSigs?.toString() || ''
     } else {

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
@@ -5,7 +5,7 @@ import { TranslateService } from '@ngx-translate/core'
 import { AlertType } from '~component/alert/alert.component'
 import { MessageService } from '~service/message.service'
 import { WalletStateService } from '~service/wallet-state-service'
-import { Attestment, ContractInfo, CoreMessageType, DLCContract, DLCMessageType, DLCState, WalletMessageType } from '~type/wallet-server-types'
+import { Attestment, ContractInfo, CoreMessageType, DLCContract, DLCMessageType, DLCState, EnumContractDescriptor, NumericContractDescriptor, WalletMessageType } from '~type/wallet-server-types'
 import { formatDateTime, formatISODate, isCancelable, isExecutable, isFundingTxRebroadcastable, isRefundable, validateHexString } from '~util/utils'
 import { getMessageBody } from '~util/wallet-server-util'
 
@@ -15,6 +15,8 @@ import { getMessageBody } from '~util/wallet-server-util'
   styleUrls: ['./contract-detail.component.scss']
 })
 export class ContractDetailComponent implements OnInit {
+
+  public Object = Object
 
   public AlertType = AlertType
   public DLCState = DLCState
@@ -31,6 +33,17 @@ export class ContractDetailComponent implements OnInit {
   _contractInfo!: ContractInfo
   get contractInfo(): ContractInfo { return this._contractInfo }
   @Input() set contractInfo(e: ContractInfo) { this._contractInfo = e }
+
+  getEnumContractDescriptor() {
+    return <EnumContractDescriptor>this.contractInfo.contractDescriptor
+  }
+
+  getContractDescriptor() {
+    if (this.isEnum())
+      return <EnumContractDescriptor>this.contractInfo.contractDescriptor
+    else // if (this.isNumeric())
+      return <NumericContractDescriptor>this.contractInfo.contractDescriptor
+  }
 
   @Output() close: EventEmitter<void> = new EventEmitter()
 
@@ -54,6 +67,16 @@ export class ContractDetailComponent implements OnInit {
 
   ngOnInit(): void {
     
+  }
+
+  isEnum() {
+    const cd = <EnumContractDescriptor><unknown>this.contractInfo.contractDescriptor
+    return cd.outcomes !== undefined
+  }
+
+  isNumeric() {
+    const cd = <NumericContractDescriptor><unknown>this.contractInfo.contractDescriptor
+    return cd.numDigits !== undefined
   }
 
   onCancelContract() {
@@ -216,6 +239,14 @@ export class ContractDetailComponent implements OnInit {
     // val url =
     //   GUIUtil.getAnnouncementUrl(GlobalData.network, primaryOracle)
     // GUIUtil.openUrl(url)
+  }
+
+  getOutcomeValue(outcomeValue: number) {
+    if (this.dlc.isInitiator) {
+      return outcomeValue
+    } else {
+      return this.dlc.totalCollateral - outcomeValue
+    }
   }
 
 }

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
@@ -182,7 +182,7 @@ export class ContractDetailComponent implements OnInit {
     console.debug('onRefund()')
 
     const contractId = this.dlc.contractId
-    const noBroadcast = false;
+    const noBroadcast = false
 
     this.messsageService.sendMessage(getMessageBody(WalletMessageType.executedlcrefund, [contractId, noBroadcast])).subscribe(r => {
       console.debug('executedlcrefund', r)

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.html
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.html
@@ -47,18 +47,18 @@
       </ng-container>
       <ng-container matColumnDef="lastUpdated">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'contracts.lastUpdated' | translate }}</th>
-        <td mat-cell *matCellDef="let contract">{{ contract.lastUpdated }}</td>
+        <td mat-cell *matCellDef="let contract">{{ formatDate(contract.lastUpdated) }}</td>
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let contract; columns: displayedColumns"
           (click)="onRowClick(contract)"
-          [class.focus-row]="selectedDLC === contract"></tr>
+          [class.focus-row]="selectedDLCContract === contract"></tr>
     </table>
   </div>
 
-  <app-contract-detail *ngIf="selectedDLC" 
+  <!-- <app-contract-detail *ngIf="selectedDLC" 
     [dlc]="selectedDLC" [contractInfo]="selectedContractInfo"
-    (close)="onCloseContractDetail()"></app-contract-detail>
+    (close)="onCloseContractDetail()"></app-contract-detail> -->
 
 </section>

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.html
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.html
@@ -46,7 +46,7 @@
       </ng-container>
       <ng-container matColumnDef="lastUpdated">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'contracts.lastUpdated' | translate }}</th>
-        <td mat-cell *matCellDef="let contract">{{ formatDate(contract.lastUpdated) }}</td>
+        <td mat-cell *matCellDef="let contract">{{ formatISODate(contract.lastUpdated) }}</td>
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.html
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.html
@@ -2,6 +2,7 @@
   <div class="section-header">
     <h2 translate>contracts.heading</h2>
     <!-- <button mat-icon-button class="close-button" (click)="onClose()"><mat-icon>close</mat-icon></button> -->
+    <button mat-icon-button class="refresh-button" matTooltip="{{ 'action.reload' | translate }}" (click)="onRefresh()"><mat-icon>refresh</mat-icon></button>
   </div>
 
   <div *ngIf="walletStateService.dlcs" class="contract-container">
@@ -9,16 +10,14 @@
       <ng-container matColumnDef="eventId">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'contracts.eventId' | translate }}</th>
         <!-- Compiler Not happy with the following type of notation -->
-        <!-- let contractInfo = walletStateService.contractInfos.value[contract.dlcId]" -->
         <td mat-cell *matCellDef="let contract">
           {{ getContractInfo(contract.dlcId)?.oracleInfo?.announcement?.event?.eventId }}
-          <!-- {{ contractInfo.oracleInfo.announcement.event.eventId }} -->
         </td>
       </ng-container>
       <ng-container matColumnDef="contractId">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'contracts.contractId' | translate }}</th>
         <td mat-cell *matCellDef="let contract">
-          <!-- Not sure yet -->
+          {{ formatShortHex( getContractId(contract.dlcId) ) }}
         </td>
       </ng-container>
       <ng-container matColumnDef="state">
@@ -27,23 +26,23 @@
       </ng-container>
       <ng-container matColumnDef="realizedPNL">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'contracts.realizedPNL' | translate }}</th>
-        <td mat-cell *matCellDef="let contract">{{ contract.realizedPNL }}</td>
+        <td mat-cell *matCellDef="let contract">{{ contract.pnl ? contract.pnl + ' ' + ('unit.sats' | translate) : ''}}</td>
       </ng-container>
       <ng-container matColumnDef="rateOfReturn">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'contracts.rateOfReturn' | translate }}</th>
-        <td mat-cell *matCellDef="let contract">{{ contract.rateOfReturn }}</td>
+        <td mat-cell *matCellDef="let contract">{{ contract.rateOfReturn ? formatPercent(contract.rateOfReturn) + '%' : '' }}</td>
       </ng-container>
       <ng-container matColumnDef="collateral">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'contracts.collateral' | translate }}</th>
-        <td mat-cell *matCellDef="let contract">{{ contract.localCollateral }}</td>
+        <td mat-cell *matCellDef="let contract">{{ contract.localCollateral + ' ' + ('unit.sats' | translate) }}</td>
       </ng-container>
       <ng-container matColumnDef="counterpartyCollateral">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'contracts.counterpartyCollateral' | translate }}</th>
-        <td mat-cell *matCellDef="let contract">{{ contract.remoteCollateral }}</td>
+        <td mat-cell *matCellDef="let contract">{{ contract.remoteCollateral + ' ' + ('unit.sats' | translate) }}</td>
       </ng-container>
       <ng-container matColumnDef="totalCollateral">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'contracts.totalCollateral' | translate }}</th>
-        <td mat-cell *matCellDef="let contract">{{ contract.totalCollateral }}</td>
+        <td mat-cell *matCellDef="let contract">{{ contract.totalCollateral + ' ' + ('unit.sats' | translate) }}</td>
       </ng-container>
       <ng-container matColumnDef="lastUpdated">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'contracts.lastUpdated' | translate }}</th>
@@ -56,9 +55,5 @@
           [class.focus-row]="selectedDLCContract === contract"></tr>
     </table>
   </div>
-
-  <!-- <app-contract-detail *ngIf="selectedDLC" 
-    [dlc]="selectedDLC" [contractInfo]="selectedContractInfo"
-    (close)="onCloseContractDetail()"></app-contract-detail> -->
 
 </section>

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.html
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.html
@@ -53,6 +53,11 @@
       <tr mat-row *matRowDef="let contract; columns: displayedColumns"
           (click)="onRowClick(contract)"
           [class.focus-row]="selectedDLCContract === contract"></tr>
+      <tr class="mat-row mat-no-data-row" *matNoDataRow>
+        <td class="mat-cell" colspan="9999">
+          {{ 'contracts.noContracts' | translate }}
+        </td>
+      </tr>
     </table>
   </div>
 

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.scss
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.scss
@@ -18,6 +18,9 @@
       .focus-row {
         font-weight: bold;
       }
+      .mat-no-data-row {
+        text-align: center;
+      }
     }
   }
 }

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.scss
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.scss
@@ -3,6 +3,18 @@
 
   .contract-container {
     .contract-table {
+      // Column padding
+      .mat-header-cell, .mat-cell, .mat-footer-cell {
+        padding-left: 1rem;
+        padding-right: 1rem; //2rem;
+        &:first-of-type {
+          padding-left: 1rem;
+        }
+        &:last-of-type {
+          padding-right: 1rem;
+        }
+      }
+
       .focus-row {
         font-weight: bold;
       }

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.scss
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.scss
@@ -1,5 +1,5 @@
 .contracts {
-
+  margin-bottom: 2rem;
 
   .contract-container {
     .contract-table {

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.ts
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.ts
@@ -6,6 +6,8 @@ import { BehaviorSubject } from 'rxjs'
 import { WalletStateService } from '~service/wallet-state-service'
 import { ContractInfo, DLCContract } from '~type/wallet-server-types'
 
+import { formatPercent, formatShortHex } from '~util/utils'
+
 
 export type DLCContractInfo = { dlc: DLCContract, contractInfo: ContractInfo }
 
@@ -15,6 +17,9 @@ export type DLCContractInfo = { dlc: DLCContract, contractInfo: ContractInfo }
   styleUrls: ['./contracts.component.scss']
 })
 export class ContractsComponent implements OnInit, AfterViewInit {
+
+  public formatPercent = formatPercent
+  public formatShortHex = formatShortHex
 
   @ViewChild(MatTable) table: MatTable<DLCContract>
   @ViewChild(MatSort) sort: MatSort
@@ -37,6 +42,12 @@ export class ContractsComponent implements OnInit, AfterViewInit {
     return this.walletStateService.contractInfos.value[dlcId]
   }
 
+  getContractId(dlcId: string) {
+    const dlc = this.walletStateService.dlcs.value.find(d => d.dlcId === dlcId)
+    if (dlc) return dlc.contractId
+    return null
+  }
+
   constructor(public walletStateService: WalletStateService) { }
 
   ngOnInit(): void {
@@ -49,6 +60,13 @@ export class ContractsComponent implements OnInit, AfterViewInit {
       this.dataSource.data = this.walletStateService.dlcs.value
       this.table.renderRows()
     })
+  }
+
+  // TODO : Reset focused item post-refresh
+  onRefresh() {
+    console.debug('onRefresh()')
+    // Force update DLC list
+    this.walletStateService.refreshDLCStates()
   }
 
   onRowClick(dlcContract: DLCContract) {

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.ts
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core'
-import { MatSort } from '@angular/material/sort'
+import { MatSort, MatSortable } from '@angular/material/sort'
 import { MatTable, MatTableDataSource } from '@angular/material/table'
 import { BehaviorSubject } from 'rxjs'
 
@@ -52,9 +52,12 @@ export class ContractsComponent implements OnInit, AfterViewInit {
   constructor(public walletStateService: WalletStateService) { }
 
   ngOnInit(): void {
+    
   }
 
   ngAfterViewInit() {
+    // Set default sort
+    this.sort.sort(<MatSortable>{ id: 'lastUpdated', start: 'desc'})
     this.dataSource.sort = this.sort;
 
     this.walletStateService.dlcs.subscribe(_ => {

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.ts
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.ts
@@ -1,10 +1,13 @@
-import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core'
+import { AfterViewInit, Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core'
 import { MatSort } from '@angular/material/sort'
 import { MatTable, MatTableDataSource } from '@angular/material/table'
+import { BehaviorSubject } from 'rxjs'
 
 import { WalletStateService } from '~service/wallet-state-service'
 import { ContractInfo, DLCContract } from '~type/wallet-server-types'
 
+
+export type DLCContractInfo = { dlc: DLCContract, contractInfo: ContractInfo }
 
 @Component({
   selector: 'app-contracts',
@@ -16,13 +19,19 @@ export class ContractsComponent implements OnInit, AfterViewInit {
   @ViewChild(MatTable) table: MatTable<DLCContract>
   @ViewChild(MatSort) sort: MatSort
 
+  @Input() clearSelection() {
+    console.debug('clearSelection()')
+    this.selectedDLCContract = <DLCContract><unknown>null
+  }
+  @Output() selectedDLC: EventEmitter<DLCContractInfo> = new EventEmitter()
+
   // Grid config
   dataSource = new MatTableDataSource(<DLCContract[]>[])
   displayedColumns = ['eventId', 'contractId', 'state', 'realizedPNL', 'rateOfReturn', 
     'collateral', 'counterpartyCollateral', 'totalCollateral', 'lastUpdated']
 
-  selectedDLC: DLCContract
-  selectedContractInfo: ContractInfo
+  selectedDLCContract: DLCContract
+  // selectedContractInfo: ContractInfo
 
   getContractInfo(dlcId: string) {
     return this.walletStateService.contractInfos.value[dlcId]
@@ -45,21 +54,31 @@ export class ContractsComponent implements OnInit, AfterViewInit {
   onRowClick(dlcContract: DLCContract) {
     console.debug('onRowClick()', dlcContract)
 
-    this.selectedDLC = dlcContract
-    this.showContractDetail(dlcContract)
+    this.selectedDLCContract = dlcContract
+
+    this.selectedDLC.emit(<DLCContractInfo>{
+      dlc: dlcContract,
+      contractInfo: this.walletStateService.contractInfos.value[dlcContract.dlcId],
+    })
+
+    // this.showContractDetail(dlcContract)
   }
 
-  showContractDetail(dlcContract: DLCContract) {
-    console.debug('showContractDetail()', dlcContract)
-
-    this.selectedContractInfo = this.walletStateService.contractInfos.value[dlcContract.dlcId]
-    console.debug('selectedContractInfo:', this.selectedContractInfo)
+  formatDate(isoDate: string) {
+    return new Date(isoDate).toLocaleDateString()
   }
 
-  onCloseContractDetail() {
-    console.debug('onCloseContractDetail()')
-    this.selectedDLC = <DLCContract><unknown>undefined
-    this.selectedContractInfo = <ContractInfo><unknown>undefined
-  }
+  // showContractDetail(dlcContract: DLCContract) {
+  //   console.debug('showContractDetail()', dlcContract)
+
+  //   this.selectedContractInfo = this.walletStateService.contractInfos.value[dlcContract.dlcId]
+  //   console.debug('selectedContractInfo:', this.selectedContractInfo)
+  // }
+
+  // onCloseContractDetail() {
+  //   console.debug('onCloseContractDetail()')
+  //   this.selectedDLC = <DLCContract><unknown>undefined
+  //   this.selectedContractInfo = <ContractInfo><unknown>undefined
+  // }
 
 }

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.ts
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.ts
@@ -6,7 +6,7 @@ import { BehaviorSubject } from 'rxjs'
 import { WalletStateService } from '~service/wallet-state-service'
 import { ContractInfo, DLCContract } from '~type/wallet-server-types'
 
-import { formatPercent, formatShortHex } from '~util/utils'
+import { formatISODate, formatPercent, formatShortHex } from '~util/utils'
 
 
 export type DLCContractInfo = { dlc: DLCContract, contractInfo: ContractInfo }
@@ -18,6 +18,7 @@ export type DLCContractInfo = { dlc: DLCContract, contractInfo: ContractInfo }
 })
 export class ContractsComponent implements OnInit, AfterViewInit {
 
+  public formatISODate = formatISODate
   public formatPercent = formatPercent
   public formatShortHex = formatShortHex
 
@@ -80,10 +81,6 @@ export class ContractsComponent implements OnInit, AfterViewInit {
     })
 
     // this.showContractDetail(dlcContract)
-  }
-
-  formatDate(isoDate: string) {
-    return new Date(isoDate).toLocaleDateString()
   }
 
   // showContractDetail(dlcContract: DLCContract) {

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.ts
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.ts
@@ -71,7 +71,7 @@ export class ContractsComponent implements OnInit, AfterViewInit {
   }
 
   onRowClick(dlcContract: DLCContract) {
-    console.debug('onRowClick()', dlcContract)
+    console.debug('onRowClick()', dlcContract, this.walletStateService.contractInfos.value[dlcContract.dlcId])
 
     this.selectedDLCContract = dlcContract
 

--- a/wallet-server-ui/src/app/component/more-info/more-info.component.ts
+++ b/wallet-server-ui/src/app/component/more-info/more-info.component.ts
@@ -25,6 +25,14 @@ export class MoreInfoComponent {
     this._tooltip = this.translate.instant(value)
   }
 
+  // _params: any = null
+  // @Input()
+  // set params(value: any) {
+  //   this._params = this.translate.instant(value)
+  //   // Best way to handle?
+  //   this._tooltip = this.translate.instant(this._tooltip, this._tooltip)
+  // }
+
   constructor(private translate: TranslateService) { }
 
 }

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
@@ -15,6 +15,11 @@
         <label>{{ (announcement ? 'newOffer.oracleAnnouncement' : contractInfo ? 'newOffer.contractInfo' : '') | translate }}</label>
         <input [value]="hex" disabled>
       </div>
+      <div class="field-group">
+        <label translate>newOffer.maturityDate</label>
+        <!-- TODO : Locale Format -->
+        <input [(ngModel)]="event.maturity" disabled>
+      </div>
     </div>
 
     <div *ngIf="isEnum()" class="enum-offer">
@@ -26,7 +31,7 @@
         </div>
         <div *ngFor="let label of enumEventDescriptor.outcomes" class="field-group enum-payout-group">
           <label class="outcome-label text-right">{{ label }}</label>
-          <input type="number" placeholder="{{ 'unit.satoshis' | translate }}" [(ngModel)]="outcomeValues[label]">
+          <input type="number" placeholder="{{ 'unit.satoshis' | translate }}" [(ngModel)]="outcomeValues[label]" min="0">
         </div>
       </div>
     </div>
@@ -48,7 +53,7 @@
         </div>
         <div *ngFor="let point of points; let i = index" class="numeric-payout-group">
           <input class="text-right" type="number" [(ngModel)]="point.outcome">
-          <input class="text-right" type="number" placeholder="{{ 'unit.satoshis' | translate }}" [(ngModel)]="point.payout">
+          <input class="text-right" type="number" placeholder="{{ 'unit.satoshis' | translate }}" [(ngModel)]="point.payout" min="0">
           <input type="checkbox" [(ngModel)]="point.isEndpoint">
           <button *ngIf="!(i === 0 || i === points.length-1)"
             mat-mini-fab class="mat-fab-sm" (click)="onRemovePointClicked(point)">
@@ -98,7 +103,8 @@
       </div>
       <div class="field-group">
         <label translate>newOffer.refundDate</label>
-        <input [(ngModel)]="event.maturity">
+        <!-- TODO : Should not be set to anything, come from datepicker -->
+        <input [(ngModel)]="refundDate">
         <app-more-info matSuffix tooltip="newOfferDescription.refundDate"></app-more-info>
       </div>
 

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
@@ -1,7 +1,9 @@
 <section class="new-offer" *ngIf="announcement || contractInfo">
   <div class="section-header">
     <h2 translate>newOffer.heading</h2>
-    <!-- <button mat-icon-button class="close-button" (click)="onClose()"><mat-icon>close</mat-icon></button> -->
+    <button mat-icon-button class="close-button" matTooltip="{{ 'action.close' | translate }}" (click)="onClose()">
+      <mat-icon>close</mat-icon>
+    </button>
   </div>
 
   <div>
@@ -18,7 +20,7 @@
       <div class="field-group">
         <label translate>newOffer.maturityDate</label>
         <!-- TODO : Locale Format -->
-        <input [(ngModel)]="event.maturity" disabled>
+        <input [value]="maturityDate" disabled>
       </div>
     </div>
 

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
@@ -8,12 +8,12 @@
 
     <div class="both">
       <div class="field-group">
-        <label>{{ (announcement ? 'newOffer.oracleAnnouncement' : contractInfo ? 'newOffer.contractInfo' : '') | translate }}</label>
-        <input [value]="hex" disabled>
+        <label translate>newOffer.eventId</label>
+        <input class="event-id-input " [(ngModel)]="event.eventId" disabled>
       </div>
       <div class="field-group">
-        <label translate>newOffer.eventId</label>
-        <input [(ngModel)]="event.eventId" disabled>
+        <label>{{ (announcement ? 'newOffer.oracleAnnouncement' : contractInfo ? 'newOffer.contractInfo' : '') | translate }}</label>
+        <input [value]="hex" disabled>
       </div>
     </div>
 
@@ -97,14 +97,17 @@
         <app-more-info matSuffix tooltip="newOfferDescription.yourCollateral" params="{ unit: unit.sats }"></app-more-info>
       </div>
       <div class="field-group">
-        <label translate>newOffer.feeRate</label>
-        <input type="nummber" placeholder="{{ 'unit.satsPerVbyte' | translate }}" [(ngModel)]="feeRate">
-        <app-more-info matSuffix tooltip="newOfferDescription.feeRate"></app-more-info>
-      </div>
-      <div class="field-group">
         <label translate>newOffer.refundDate</label>
         <input [(ngModel)]="event.maturity">
         <app-more-info matSuffix tooltip="newOfferDescription.refundDate"></app-more-info>
+      </div>
+
+      <div class="spacer"></div>
+
+      <div class="field-group">
+        <label translate>newOffer.feeRate</label>
+        <input type="nummber" placeholder="{{ 'unit.satsPerVbyte' | translate }}" [(ngModel)]="feeRate">
+        <app-more-info matSuffix tooltip="newOfferDescription.feeRate"></app-more-info>
       </div>
     </div>
 

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
@@ -13,14 +13,19 @@
         <label translate>newOffer.eventId</label>
         <input class="event-id-input " [(ngModel)]="event.eventId" disabled>
       </div>
-      <div class="field-group">
-        <label>{{ (announcement ? 'newOffer.oracleAnnouncement' : contractInfo ? 'newOffer.contractInfo' : '') | translate }}</label>
-        <input [value]="hex" disabled>
-      </div>
+
+      <div class="spacer"></div>
+
       <div class="field-group">
         <label translate>newOffer.maturityDate</label>
         <!-- TODO : Locale Format -->
         <input [value]="maturityDate" disabled>
+      </div>
+      <div class="field-group">
+        <label translate>newOffer.refundDate</label>
+        <!-- TODO : Should not be set to anything, come from datepicker -->
+        <input [(ngModel)]="refundDate">
+        <app-more-info matSuffix tooltip="newOfferDescription.refundDate"></app-more-info>
       </div>
     </div>
 
@@ -103,11 +108,12 @@
         <input type="nummber" placeholder="{{ 'unit.satoshis' | translate }}" [(ngModel)]="yourCollateral">
         <app-more-info matSuffix tooltip="newOfferDescription.yourCollateral" params="{ unit: unit.sats }"></app-more-info>
       </div>
+
+      <div class="spacer"></div>
+
       <div class="field-group">
-        <label translate>newOffer.refundDate</label>
-        <!-- TODO : Should not be set to anything, come from datepicker -->
-        <input [(ngModel)]="refundDate">
-        <app-more-info matSuffix tooltip="newOfferDescription.refundDate"></app-more-info>
+        <label>{{ (announcement ? 'newOffer.oracleAnnouncement' : contractInfo ? 'newOffer.contractInfo' : '') | translate }}</label>
+        <input [value]="hex" disabled>
       </div>
 
       <div class="spacer"></div>
@@ -124,6 +130,7 @@
         <button mat-stroked-button color="primary" (click)="onExecute()"
           [disabled]="!inputsValid()">{{ 'action.execute' | translate }}</button>
       </div>
+      
       <fieldset class="result-group" [disabled]="!newOfferResult">
         <label translate>result</label>
         <textarea class="result-textarea" [(ngModel)]="newOfferResult"></textarea>

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
@@ -56,7 +56,8 @@
         </div>
       </div>
 
-      <mat-accordion class="rounding-info">
+      <!-- These are not supported on the backend yet -->
+      <mat-accordion class="rounding-info" hidden>
         <mat-expansion-panel disabled>
           <mat-expansion-panel-header>
             <mat-panel-title>

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
@@ -1,4 +1,4 @@
-<section class="new-offer" *ngIf="announcement">
+<section class="new-offer" *ngIf="announcement || contractInfo">
   <div class="section-header">
     <h2 translate>newOffer.heading</h2>
     <!-- <button mat-icon-button class="close-button" (click)="onClose()"><mat-icon>close</mat-icon></button> -->
@@ -8,12 +8,12 @@
 
     <div class="both">
       <div class="field-group">
-        <label translate>newOffer.oracleAnnouncementOrContractInfo</label>
-        <input [value]="announcement.hex" disabled>
+        <label>{{ (announcement ? 'newOffer.oracleAnnouncement' : contractInfo ? 'newOffer.contractInfo' : '') | translate }}</label>
+        <input [value]="hex" disabled>
       </div>
       <div class="field-group">
         <label translate>newOffer.eventId</label>
-        <input [value]="announcement.announcement.event.eventId" disabled>
+        <input [(ngModel)]="event.eventId" disabled>
       </div>
     </div>
 
@@ -32,10 +32,11 @@
     </div>
 
     <div *ngIf="isNumeric()" class="numeric-offer">
-
       <div class="points-group text-center">
         <label translate>newOffer.points</label>
-        <button mat-mini-fab class="mat-fab-sm" (click)="addNewPoint()"><mat-icon>add</mat-icon></button>
+        <button mat-mini-fab class="mat-fab-sm" (click)="addNewPoint()">
+          <mat-icon>add</mat-icon>
+        </button>
         <!-- <button mat-icon-button (click)="addNewPoint()"><mat-icon class="mat-icon-sm">add</mat-icon></button> -->
       </div>
 
@@ -45,27 +46,28 @@
           <label class="payout-label text-center" translate>newOffer.payout</label>
           <label class="endpoint-label text-center" translate>newOffer.endpoint</label>
         </div>
-
-        <!-- TODO : Allow removing points -->
         <div *ngFor="let point of points; let i = index" class="numeric-payout-group">
           <input class="text-right" type="number" [(ngModel)]="point.outcome">
           <input class="text-right" type="number" placeholder="{{ 'unit.satoshis' | translate }}" [(ngModel)]="point.payout">
           <input type="checkbox" [(ngModel)]="point.isEndpoint">
           <button *ngIf="!(i === 0 || i === points.length-1)"
-            mat-mini-fab class="mat-fab-sm"  (click)="onRemovePointClicked(point)"><mat-icon>remove</mat-icon></button>
+            mat-mini-fab class="mat-fab-sm" (click)="onRemovePointClicked(point)">
+            <mat-icon>remove</mat-icon>
+          </button>
         </div>
       </div>
 
       <!-- These are not supported on the backend yet -->
-      <mat-accordion class="rounding-info" hidden>
+      <!--
+      <mat-accordion class="rounding-info">
         <mat-expansion-panel disabled>
           <mat-expansion-panel-header>
             <mat-panel-title>
               {{ 'newOffer.roundingInfo' | translate }}
             </mat-panel-title>
-            <!-- <mat-panel-description>
+            <mat-panel-description>
               Description
-            </mat-panel-description> -->
+            </mat-panel-description>
           </mat-expansion-panel-header>
           <div>
             <div class="points-group text-center">
@@ -85,7 +87,7 @@
           </div>
         </mat-expansion-panel>
       </mat-accordion>
-     
+      -->
     </div>
 
     <div class="both">
@@ -101,7 +103,7 @@
       </div>
       <div class="field-group">
         <label translate>newOffer.refundDate</label>
-        <input [value]="announcement.announcement.event.maturity">
+        <input [(ngModel)]="event.maturity">
         <app-more-info matSuffix tooltip="newOfferDescription.refundDate"></app-more-info>
       </div>
     </div>

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
@@ -1,10 +1,10 @@
-<section class="new-offer">
+<section class="new-offer" *ngIf="announcement">
   <div class="section-header">
     <h2 translate>newOffer.heading</h2>
     <!-- <button mat-icon-button class="close-button" (click)="onClose()"><mat-icon>close</mat-icon></button> -->
   </div>
 
-  <div *ngIf="announcement">
+  <div>
 
     <div class="both">
       <div class="field-group">
@@ -24,7 +24,7 @@
           <label class="payout-label text-center" translate>newOffer.payout</label>
           <app-more-info matSuffix tooltip="newOfferDescription.outcomes"></app-more-info>
         </div>
-        <div *ngFor="let label of enumEventDescriptor.outcomes" class="field-group">
+        <div *ngFor="let label of enumEventDescriptor.outcomes" class="field-group enum-payout-group">
           <label class="outcome-label text-right">{{ label }}</label>
           <input type="number" placeholder="{{ 'unit.satoshis' | translate }}" [(ngModel)]="outcomeValues[label]">
         </div>
@@ -32,10 +32,11 @@
     </div>
 
     <div *ngIf="isNumeric()" class="numeric-offer">
-      
+
       <div class="points-group text-center">
         <label translate>newOffer.points</label>
-        <button mat-icon-button (click)="addNewPoint()">+</button>
+        <button mat-mini-fab class="mat-fab-sm" (click)="addNewPoint()"><mat-icon>add</mat-icon></button>
+        <!-- <button mat-icon-button (click)="addNewPoint()"><mat-icon class="mat-icon-sm">add</mat-icon></button> -->
       </div>
 
       <div class="outcome-group">
@@ -46,20 +47,51 @@
         </div>
 
         <!-- TODO : Allow removing points -->
-        <div *ngFor="let point of points" class="numeric-payout-group">
+        <div *ngFor="let point of points; let i = index" class="numeric-payout-group">
           <input class="text-right" type="number" [(ngModel)]="point.outcome">
           <input class="text-right" type="number" placeholder="{{ 'unit.satoshis' | translate }}" [(ngModel)]="point.payout">
           <input type="checkbox" [(ngModel)]="point.isEndpoint">
+          <button *ngIf="!(i === 0 || i === points.length-1)"
+            mat-mini-fab class="mat-fab-sm"  (click)="onRemovePointClicked(point)"><mat-icon>remove</mat-icon></button>
         </div>
       </div>
 
+      <mat-accordion class="rounding-info">
+        <mat-expansion-panel disabled>
+          <mat-expansion-panel-header>
+            <mat-panel-title>
+              {{ 'newOffer.roundingInfo' | translate }}
+            </mat-panel-title>
+            <!-- <mat-panel-description>
+              Description
+            </mat-panel-description> -->
+          </mat-expansion-panel-header>
+          <div>
+            <div class="points-group text-center">
+              <label translate>newOffer.roundingIntervals</label>
+              <button mat-mini-fab class="mat-fab-sm" (click)="addNewRoundingInterval()">+</button>
+            </div>
+
+            <div class="rounding-interval-group">
+              <label class="outcome-label text-center" translate>newOffer.outcome</label>
+              <label class="rounding-level-label text-center" translate>newOffer.roundingLevel</label>
+            </div>
+
+            <div *ngFor="let ri of roundingIntervals; let i = index" class="rounding-interval-group">
+              <input class="text-right" type="number" [(ngModel)]="ri.outcome">
+              <input class="text-right" type="number" placeholder="{{ 'unit.satoshis' | translate }}" [(ngModel)]="ri.roundingLevel">
+            </div>
+          </div>
+        </mat-expansion-panel>
+      </mat-accordion>
+     
     </div>
 
     <div class="both">
       <div class="field-group">
         <label translate>newOffer.yourCollateral</label>
         <input type="nummber" placeholder="{{ 'unit.satoshis' | translate }}" [(ngModel)]="yourCollateral">
-        <app-more-info matSuffix tooltip="newOfferDescription.yourCollateral"></app-more-info>
+        <app-more-info matSuffix tooltip="newOfferDescription.yourCollateral" params="{ unit: unit.sats }"></app-more-info>
       </div>
       <div class="field-group">
         <label translate>newOffer.feeRate</label>
@@ -79,6 +111,7 @@
           [disabled]="!inputsValid()">{{ 'action.execute' | translate }}</button>
       </div>
       <fieldset class="result-group" [disabled]="!newOfferResult">
+        <label translate>result</label>
         <textarea class="result-textarea" [(ngModel)]="newOfferResult"></textarea>
         <button mat-icon-button class="copy-button" matTooltip="{{ 'action.copyToClipboard' | translate }}"
           (click)="onCopyResult()"><mat-icon>content_copy</mat-icon></button>

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.scss
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.scss
@@ -12,10 +12,10 @@
       }
     }
     .outcome-group {
-      margin: 1.5rem;
+      margin: 1rem;
 
       .outcome-label {
-        margin-right: 0.5rem;
+        margin-right: 1rem;
       }
 
       .field-group {
@@ -34,7 +34,20 @@
           width: 10rem;
         }
       }
+      .enum-payout-group {
+        display: flex;
+        flex-direction: row;
+
+        align-items: center;
+        min-height: 40px; // Matching numeric-payout-group for now
+      }
       .numeric-payout-group {
+        display: flex;
+        flex-direction: row;
+
+        align-items: center;
+        min-height: 40px; // Matches remove buttons on inner rows
+
         &:first-of-type {
           margin-bottom: 0.5rem;
         }
@@ -51,11 +64,9 @@
         .endpoint-label {
           width: 3rem;
         }
-        input[type="text"] {
-          width: 6rem;
-        }
         input[type="number"] {
           width: 6rem;
+          margin-right: 0.25rem;
         }
         input[type="checkbox"] {
           width: 3rem;
@@ -63,9 +74,24 @@
         }
       }
     }
-    .points-group {
-      width: 18rem;
-      margin-top: 0.5rem;
+    .rounding-info {
+      margin-bottom: 1rem;
+
+      .rounding-interval-group {
+        display: flex;
+        flex-direction: row;
+  
+        align-items: center;
+  
+  
+      }
+      .points-group {
+        width: 18rem;
+  
+        > label {
+          margin-right: 0.5rem;
+        }
+      }
     }
   }
 
@@ -81,15 +107,21 @@
   .footer {
     // display: flex;
     // flex-direction: row;
-    width: 36rem;
+    // width: 36rem;
     .button-group {
       text-align: right;
     }
     .result-group {
-      // flex: 1;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
 
+      label {
+        margin-right: 1rem;
+      }
       .result-textarea {
-        width: 80%;
+        // width: 80%;
+        flex: 1;
       }
     }
   }

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.scss
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.scss
@@ -11,6 +11,11 @@
         width: 10rem;
       }
     }
+
+    .event-id-input {
+      width: 20rem !important;
+    }
+
     .outcome-group {
       margin: 1rem;
 
@@ -93,6 +98,10 @@
         }
       }
     }
+  }
+
+  .spacer {
+    height: 1.5rem;
   }
 
   .numeric-offer {

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.scss
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.scss
@@ -8,7 +8,7 @@
       }
       input {
         display: inline-block;
-        width: 10rem;
+        width: 12rem;
       }
     }
 
@@ -87,8 +87,6 @@
         flex-direction: row;
   
         align-items: center;
-  
-  
       }
       .points-group {
         width: 18rem;
@@ -100,38 +98,27 @@
     }
   }
 
-  .spacer {
-    height: 1.5rem;
+  .enum-offer {
+    margin: 1.5rem;
   }
 
   .numeric-offer {
     display: flex;
     flex-direction: column;
-
-    width: 36rem;
-
     align-items: center;
+
+    margin: 1.5rem;
+  }
+
+  .spacer {
+    height: 1.5rem;
   }
 
   .footer {
-    // display: flex;
-    // flex-direction: row;
-    // width: 36rem;
+    margin-top: 1rem;
+    
     .button-group {
       text-align: right;
-    }
-    .result-group {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-
-      label {
-        margin-right: 1rem;
-      }
-      .result-textarea {
-        // width: 80%;
-        flex: 1;
-      }
     }
   }
   

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
@@ -70,7 +70,7 @@ export class NewOfferComponent implements OnInit {
   }
 
   yourCollateral: number // wallet users funds in contract
-  feeRate: number = 1
+  feeRate: number = 1 // TODO : From estimated fee rate
 
   newOfferResult: string = ''
 
@@ -262,7 +262,9 @@ export class NewOfferComponent implements OnInit {
   addNewRoundingInterval() {
     console.debug('addNewRoundingInterval()')
 
-    
+    // https://github.com/bitcoin-s/bitcoin-s/blob/aa748c012fc03e6bde6435092505e3c17a70437a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala#L287
+    // Structure like
+    // { "intervals" : [{"beginInterval": 123 , "roundingMod" :456 }, ...]}
   }
 
 }

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
@@ -74,8 +74,15 @@ export class NewOfferComponent implements OnInit {
     this.outcomeValues = {}
     this.points = []
     if (this.isEnum()) {
-      for (const label of this.enumEventDescriptor.outcomes) {
-        this.outcomeValues[label] = null
+      // Announcement reveals outcome values only, ContractInfo comes with values
+      if (this.announcement) {
+        for (const label of this.enumEventDescriptor.outcomes) {
+          this.outcomeValues[label] = null
+        }
+      } else if (this.contractInfo) {
+        for (const label of Object.keys(this.enumContractDescriptor.outcomes)) {
+          this.outcomeValues[label] = this.enumContractDescriptor.outcomes[label]
+        }
       }
     } else if (this.isNumeric()) {
       if (this.announcement) {
@@ -144,21 +151,8 @@ export class NewOfferComponent implements OnInit {
   onExecute() {
     console.debug('onExecute()')
 
-    // Data : https://test.oracle.suredbits.com/announcement/63fa7885e3c6052e97956961698cde2b286dc1621544bbd8fcfbd78b2b1dbdcf
-    // const enumAnnouncementHex = 'fdd824a8823cf7a3e449260f46d3d9a5bb0ddf1a367e0d3c9ce8858e16cd783392560bd1c9671314d54b6cb258bc6d85ab8fe238a27feb5a27d75323524a54d712a80b70a305b66d790ea4afe15b3fb61cae4d77f050e57b41f10f530c48a23dddbe335afdd822440001c3b0ecdaeaa3bbbd53386dec623b3a884b0ca2e2777cc62f0b6f891d9226114d614ebae0fdd80611000205546f64617908546f6d6f72726f7708546f6d6f72726f77'
-    // const totalCollateral = 200003
-    // const payoutVals = { outcomes: { 'Today': 200003, 'Tomorrow': 0 } }
-
-    // TODO : Serialize outcomes
-    // TODO : Compute total collateral
-
-    if (this.contractInfo) {
-      console.error('ContractInfo hex not yet accessible, cannot execute')
-      return
-    }
-
     // this.contractInfo.hex is no good, need announcement hex from this.contractInfo
-    const hex = this.announcement.hex // this.announcement ? this.announcement.hex : this.contractInfo.hex
+    const hex = this.announcement ? this.announcement.hex : this.contractInfo.contractInfo.oracleInfo.announcement.hex
 
     if (this.isEnum()) {
       const payoutVals = this.buildPayoutVals()

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
@@ -151,6 +151,15 @@ export class NewOfferComponent implements OnInit {
 
     // TODO : Serialize outcomes
     // TODO : Compute total collateral
+
+    if (this.contractInfo) {
+      console.error('ContractInfo hex not yet accessible, cannot execute')
+      return
+    }
+
+    // this.contractInfo.hex is no good, need announcement hex from this.contractInfo
+    const hex = this.announcement.hex // this.announcement ? this.announcement.hex : this.contractInfo.hex
+
     if (this.isEnum()) {
       const payoutVals = this.buildPayoutVals()
       const maxCollateral = this.computeMaxCollateral(payoutVals)
@@ -158,7 +167,7 @@ export class NewOfferComponent implements OnInit {
       console.debug('payoutVals:', payoutVals, 'maxCollateral:', maxCollateral)
   
       this.messageService.sendMessage(getMessageBody(DLCMessageType.createcontractinfo, 
-        [this.announcement.hex, maxCollateral, payoutVals])).subscribe(r => {
+        [hex, maxCollateral, payoutVals])).subscribe(r => {
           console.debug('createcontractinfo', r)
   
           if (r.result) {
@@ -194,7 +203,7 @@ export class NewOfferComponent implements OnInit {
       
       // console.debug('numericAnnouncementHex:', numericAnnouncementHex, 'totalCollateral:', totalCollateral, 'numericPayoutVals:', numericPayoutVals)
       this.messageService.sendMessage(getMessageBody(DLCMessageType.createcontractinfo, 
-        [this.announcement.hex, maxCollateral, numericPayoutVals])).subscribe(r => {
+        [hex, maxCollateral, numericPayoutVals])).subscribe(r => {
         console.warn('createcontractinfo', r)
 
         // Testing

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
@@ -1,10 +1,10 @@
-import { Component, Input, OnInit } from '@angular/core'
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core'
 
 import { MessageService } from '~service/message.service'
 import { WalletStateService } from '~service/wallet-state-service'
 import { CoreMessageType, DLCMessageType, EnumContractDescriptor, EnumEventDescriptor, Event, NumericContractDescriptor, NumericEventDescriptor, PayoutFunctionPoint, WalletMessageType } from '~type/wallet-server-types'
 import { AnnouncementWithHex, ContractInfoWithHex } from '~type/wallet-ui-types'
-import { copyToClipboard, dateToSecondsSinceEpoch } from '~util/utils'
+import { copyToClipboard, dateToSecondsSinceEpoch, formatDateTime } from '~util/utils'
 import { getMessageBody } from '~util/wallet-server-util'
 
 
@@ -63,12 +63,16 @@ export class NewOfferComponent implements OnInit {
     return <NumericContractDescriptor>this.contractInfo.contractInfo.contractDescriptor
   }
 
+  @Output() close: EventEmitter<void> = new EventEmitter()
+
   // getEventDescriptor() {
   //   if (this.isEnum())
   //     return <EnumEventDescriptor>this.announcement.announcement.event.descriptor
   //   else // if (this.isNumeric())
   //     return <NumericEventDescriptor>this.announcement.announcement.event.descriptor
   // }
+
+  maturityDate: string
 
   // enum
   outcomeValues: { [label: string]: number|null } = {}
@@ -83,6 +87,7 @@ export class NewOfferComponent implements OnInit {
   newOfferResult: string = ''
 
   private reset() {
+    this.maturityDate = formatDateTime(dateToSecondsSinceEpoch(new Date(this.event.maturity)))
     this.outcomeValues = {}
     this.points = []
 
@@ -116,6 +121,7 @@ export class NewOfferComponent implements OnInit {
     // May want to should maturity date on form
     this.refundDate = new Date(this.event.maturity).toISOString()
     this.feeRate = DEFAULT_FEE_RATE
+
     this.newOfferResult = ''
   }
 
@@ -130,6 +136,10 @@ export class NewOfferComponent implements OnInit {
   constructor(private messageService: MessageService, private walletStateService: WalletStateService) { }
 
   ngOnInit(): void {
+  }
+
+  onClose() {
+    this.close.next()
   }
 
   isEnum() {

--- a/wallet-server-ui/src/app/component/wallet-balance/wallet-balance.component.html
+++ b/wallet-server-ui/src/app/component/wallet-balance/wallet-balance.component.html
@@ -4,7 +4,7 @@
     <!-- <button mat-icon-button class="close-button" (click)="onClose()"><mat-icon>close</mat-icon></button> -->
   </div>
 
-  <div class="horizontal-pane">
+  <div class="wallet-state horizontal-pane">
     <div *ngIf="walletStateService.balances" class="pane balances">
       <div class="balance-group">
         <label translate>walletBalance.confirmedBalance</label>
@@ -36,7 +36,7 @@
       </div>
       <div class="pnl-group">
         <label translate>walletBalance.rateOfReturn</label>
-        <span class="value">{{ walletStateService.dlcWalletAccounting.rateOfReturn }}</span>
+        <span class="value">{{ formatPercent(walletStateService.dlcWalletAccounting.rateOfReturn) }}</span>
         <span class="unit" translate>unit.percent</span>
       </div>
     </div>

--- a/wallet-server-ui/src/app/component/wallet-balance/wallet-balance.component.scss
+++ b/wallet-server-ui/src/app/component/wallet-balance/wallet-balance.component.scss
@@ -1,41 +1,45 @@
 .wallet-balance {
 
-  .balances, .pnl {
-    .balance-group {
+  .wallet-state {
+    margin-bottom: 1rem;
+    
+    .balances, .pnl {
+      .balance-group {
+        margin-bottom: 0.25rem;
+        label {
+          display: inline-block;
+          width: 10rem;
+        }
+        .value {
+          width: 6rem;
+        }
+        // span {
+        //   display: inline-block;
+        //   width: 6rem;
+        // }
+      }
+    }
+    .pnl-group {
       margin-bottom: 0.25rem;
       label {
         display: inline-block;
-        width: 10rem;
+        width: 8rem;
       }
       .value {
-        width: 6rem;
+        // width: 3rem; // autosizing for now
       }
-      // span {
-      //   display: inline-block;
-      //   width: 6rem;
-      // }
     }
-  }
-  .pnl-group {
-    margin-bottom: 0.25rem;
-    label {
-      display: inline-block;
-      width: 8rem;
-    }
-    .value {
-      // width: 3rem; // autosizing for now
-    }
-  }
 
-  .balance-group, .pnl-group {
-    .value {
-      display: inline-block;
-      margin-right: 0.25rem;
-      text-align: right;
-    }
-    .unit {
-      display: inline-block;
-      width: 3rem;
+    .balance-group, .pnl-group {
+      .value {
+        display: inline-block;
+        margin-right: 0.25rem;
+        text-align: right;
+      }
+      .unit {
+        display: inline-block;
+        width: 3rem;
+      }
     }
   }
 }

--- a/wallet-server-ui/src/app/component/wallet-balance/wallet-balance.component.ts
+++ b/wallet-server-ui/src/app/component/wallet-balance/wallet-balance.component.ts
@@ -74,6 +74,7 @@ export class WalletBalanceComponent implements OnInit {
                     content: 'dialog.sendFundsSuccess.content',
                     action: 'action.ok',
                     // actionColor: 'primary',
+                    showCancelButton: false,
                   }
                 })
               }

--- a/wallet-server-ui/src/app/configuration/configuration.component.scss
+++ b/wallet-server-ui/src/app/configuration/configuration.component.scss
@@ -1,11 +1,8 @@
 .configuration-section {
-  padding: 0 1rem;
-
   display: flex;
   flex-direction: column;
 
   height: 100%;
-  min-width: 300px;
 
   .dark-mode {
     display: flex;

--- a/wallet-server-ui/src/app/dialog/confirmation/confirmation.component.html
+++ b/wallet-server-ui/src/app/dialog/confirmation/confirmation.component.html
@@ -1,7 +1,7 @@
 <h2 mat-dialog-title>{{ data.title | translate }}</h2>
 <mat-dialog-content [translate]="data.content" [translateParams]="data.params"></mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-stroked-button mat-dialog-close>{{ 'action.cancel' | translate }}</button>
+  <button *ngIf="data.showCancelButton" mat-stroked-button mat-dialog-close>{{ 'action.cancel' | translate }}</button>
   <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
   <button mat-stroked-button [mat-dialog-close]="true" [color]="data.actionColor">{{ data.action | translate }}</button>
 </mat-dialog-actions>

--- a/wallet-server-ui/src/app/dialog/confirmation/confirmation.component.ts
+++ b/wallet-server-ui/src/app/dialog/confirmation/confirmation.component.ts
@@ -8,6 +8,7 @@ export interface ConfirmationDialogContent {
   params: any // { key: value }
   action: string
   actionColor: string
+  showCancelButton: boolean
 }
 
 @Component({

--- a/wallet-server-ui/src/app/dialog/send-funds-dialog/send-funds-dialog.component.html
+++ b/wallet-server-ui/src/app/dialog/send-funds-dialog/send-funds-dialog.component.html
@@ -10,7 +10,8 @@
   </div>
   <div class="field-group">
     <label translate>dialog.sendFunds.amount</label>
-    <input type="number" placeholder="{{ 'unit.sats' | translate }}" [(ngModel)]="amount">
+    <input type="number" placeholder="{{ 'unit.sats' | translate }}" [(ngModel)]="amount" [disabled]="sendMax">
+    <mat-button-toggle [(ngModel)]="sendMax" (change)="onMax()">MAX</mat-button-toggle>
   </div>
   <div class="field-group">
     <label translate>dialog.sendFunds.feeRate</label>
@@ -23,6 +24,6 @@
   <button mat-stroked-button mat-dialog-close>{{ 'action.cancel' | translate }}</button>
   <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
   <button mat-stroked-button [mat-dialog-close]="true" [color]="actionColor"
-    [mat-dialog-close]="{ address, amount, feeRate }"
+    [mat-dialog-close]="{ address, amount, feeRate, sendMax }"
     [disabled]="!inputsValid()">{{ action | translate }}</button>
 </mat-dialog-actions>

--- a/wallet-server-ui/src/app/dialog/send-funds-dialog/send-funds-dialog.component.ts
+++ b/wallet-server-ui/src/app/dialog/send-funds-dialog/send-funds-dialog.component.ts
@@ -13,6 +13,7 @@ export class SendFundsDialogComponent implements OnInit {
 
   address = ''
   amount: number
+  sendMax: boolean = false
   feeRate: number
 
   action = 'action.ok'
@@ -44,6 +45,12 @@ export class SendFundsDialogComponent implements OnInit {
     }
 
     return validInputs
+  }
+
+  onMax() {
+    console.debug('onMax()', this.sendMax)
+    this.sendMax = !this.sendMax
+    if (this.sendMax) this.amount = <number><unknown>null
   }
 
 }

--- a/wallet-server-ui/src/app/shared/modules/material/material.module.ts
+++ b/wallet-server-ui/src/app/shared/modules/material/material.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common'
 
 import { MatBottomSheetModule } from '@angular/material/bottom-sheet'
 import { MatButtonModule } from '@angular/material/button'
+import { MatButtonToggleModule } from '@angular/material/button-toggle'
 import { MatCheckboxModule } from '@angular/material/checkbox'
 import { MatExpansionModule } from '@angular/material/expansion'
 import { MatDatepickerModule } from '@angular/material/datepicker'
@@ -25,6 +26,7 @@ import { MatTooltipModule } from '@angular/material/tooltip'
 const materialModules = [
   MatBottomSheetModule,
   MatButtonModule,
+  MatButtonToggleModule,
   MatCheckboxModule,
   MatExpansionModule,
   MatDatepickerModule,

--- a/wallet-server-ui/src/app/shared/modules/material/material.module.ts
+++ b/wallet-server-ui/src/app/shared/modules/material/material.module.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common'
 import { MatBottomSheetModule } from '@angular/material/bottom-sheet'
 import { MatButtonModule } from '@angular/material/button'
 import { MatCheckboxModule } from '@angular/material/checkbox'
+import { MatExpansionModule } from '@angular/material/expansion'
 import { MatDatepickerModule } from '@angular/material/datepicker'
 import { MatDialogModule } from '@angular/material/dialog'
 import { MatFormFieldModule } from '@angular/material/form-field'
@@ -25,6 +26,7 @@ const materialModules = [
   MatBottomSheetModule,
   MatButtonModule,
   MatCheckboxModule,
+  MatExpansionModule,
   MatDatepickerModule,
   MatDialogModule, // For focus
   MatFormFieldModule,

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -36,7 +36,8 @@
     "saveToFile": "Save to File",
     "copyToClipboard": "Copy to Clipboard",
     "reload": "Reload",
-    "refresh": "Refresh"
+    "refresh": "Refresh",
+    "close": "Close"
   },
 
   "unit": {
@@ -112,7 +113,9 @@
     "dlcOffer": "DLC Offer",
     "peerAddress": "Peer Address",
     "optional": "optional",
+    "required": "required",
     "eventId": "Event Id",
+    "maturityDate": "Maturity Date",
     "oraclePublicKey": "Oracle Public Key",
     "yourCollateral": "Your Collateral",
     "counterpartyCollateral": "Counterparty Collateral",

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -34,7 +34,9 @@
     "no": "No",
     "execute": "Execute",
     "saveToFile": "Save to File",
-    "copyToClipboard": "Copy to Clipboard"
+    "copyToClipboard": "Copy to Clipboard",
+    "reload": "Reload",
+    "refresh": "Refresh"
   },
 
   "unit": {
@@ -45,7 +47,8 @@
     "sat": "sat",
     "sats": "sats",
     "percent": "%",
-    "satsPerVbyte": "sats/vbyte"
+    "satsPerVbyte": "sats/vbyte",
+    "ellipsis": "..."
   },
 
   "configuration": {
@@ -150,7 +153,10 @@
     "oracleSignatures": "Oracle Signatures",
     "rebroadcast": "Rebroadcast",
     "cancelContract": "Cancel Contract",
-    "cancelContractSuccess": "Successfully canceled contract"
+    "cancelContractSuccess": "Successfully canceled contract",
+    "fundingRebroadcastSuccess": "Successfully rebroadcast funding transaction",
+    "closingRebroadcastSuccess": "Successfully rebroadcast closing transaction",
+    "refundContract": "Refund Contract"
   },
 
   "events": {

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -151,7 +151,10 @@
     "feeRate": "Fee Rate",
     "contractTimeout": "Contract Timeout",
     "outcomePayouts": "Outcome Payouts",
-    "totalCollateral": "Total Collateral",
+    "collateral": "Collateral",
+    "totalCollateral": "Total",
+    "localCollateral": "Local",
+    "remoteCollateral": "Remote",
     "fundingTransactionId": "Funding Transaction Id",
     "closingTransactionId": "Closing Transaction Id",
     "oracleSignatures": "Oracle Signatures",
@@ -160,7 +163,14 @@
     "cancelContractSuccess": "Successfully canceled contract",
     "fundingRebroadcastSuccess": "Successfully rebroadcast funding transaction",
     "closingRebroadcastSuccess": "Successfully rebroadcast closing transaction",
-    "refundContract": "Refund Contract"
+    "refundContract": "Refund Contract",
+    "viewOnOracleExplorer": "View on Oracle Explorer",
+
+    "contractOutcome": "Contract Outcome",
+    "myPayout": "My Payout",
+    "counterpartyPayout": "Counterparty Payout",
+    "pnl": "Profit or Loss",
+    "rateOfReturn": "Rate of Return"
   },
 
   "events": {
@@ -172,6 +182,7 @@
   },
 
   "dialog": {
+    "error": "Error",
     "newAddress": {
       "title": "New Address",
       "content": "{{address}}"

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -77,6 +77,8 @@
   "newOffer": {
     "heading": "New Offer",
     "oracleAnnouncementOrContractInfo": "Oracle Announcement / Contract Info",
+    "oracleAnnouncement": "Oracle Announcement",
+    "contractInfo": "Contract Info",
     "eventId": "Event Id",
     "points": "Points",
     "outcome": "Outcome",
@@ -134,7 +136,8 @@
     "collateral": "Collateral",
     "counterpartyCollateral": "Counterparty Collateral",
     "totalCollateral": "Total Collateral",
-    "lastUpdated": "Last Updated"
+    "lastUpdated": "Last Updated",
+    "noContracts": "No DLC Contracts Started"
   },
 
   "contractDetail": {
@@ -181,7 +184,7 @@
     },
     "sendFundsSuccess": {
       "title": "Funds Sent",
-      "content": "Funds Successfully Sent"
+      "content": "{{ amount }} sats successfully sent to {{ address }}"
     },
     "sendMessageError": {
       "title": "Error sending message to appServer"

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -80,6 +80,7 @@
     "oracleAnnouncement": "Oracle Announcement",
     "contractInfo": "Contract Info",
     "eventId": "Event Id",
+    "maturityDate": "Maturity Date",
     "points": "Points",
     "outcome": "Outcome",
     "payout": "Payout",

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -147,6 +147,7 @@
     "contractInfo": "Contract Info",
     "feeRate": "Fee Rate",
     "contractTimeout": "Contract Timeout",
+    "outcomePayouts": "Outcome Payouts",
     "totalCollateral": "Total Collateral",
     "fundingTransactionId": "Funding Transaction Id",
     "closingTransactionId": "Closing Transaction Id",

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -127,7 +127,7 @@
   },
 
   "acceptOfferDescription": {
-    "peerAddress": "Tor address of the person you'd like to complete the contract with.\nPutting an address in here will attempt to complete the remaining contract steps online."
+    "peerAddress": "Tor DLC Host Address of the person you'd like to complete the contract with. Putting an address in here will attempt to complete the remaining contract steps online."
   },
 
   "contracts": {
@@ -153,12 +153,13 @@
     "contractId": "Contract Id",
     "contractInfo": "Contract Info",
     "feeRate": "Fee Rate",
+    "contractMaturity": "Contract Maturity",
     "contractTimeout": "Contract Timeout",
     "outcomePayouts": "Outcome Payouts",
     "collateral": "Collateral",
     "totalCollateral": "Total",
-    "localCollateral": "Local",
-    "remoteCollateral": "Remote",
+    "localCollateral": "Your's",
+    "remoteCollateral": "Counterparty's",
     "fundingTransactionId": "Funding Transaction Id",
     "closingTransactionId": "Closing Transaction Id",
     "oracleSignatures": "Oracle Signatures",

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -1,6 +1,8 @@
 {
   "title": "Bitcoin-S Wallet",
 
+  "result": "Result",
+
   "splashScreen": {
     "heading": "Welcome to Bitcoin-S Wallet",
     "betaSoftware": "This application is beta software.",
@@ -81,14 +83,14 @@
     "roundingIntervals": "Rounding Intervals",
     "roundingLevel": "Rounding Level",
     "yourCollateral": "Your Collateral",
-    "feeRate": "Fee Rate (sats/vbyte)",
+    "feeRate": "Fee Rate",
     "refundDate": "Refund Date"
   },
 
   "newOfferDescription": {
     "outcomes": "Payout values are to you, in sats, for the given outcome",
-    "yourCollateral": "Your collateral at stake",
-    "feeRate": "Fee Rate built into contract",
+    "yourCollateral": "Your collateral at stake (sats)",
+    "feeRate": "Fee Rate built into contract (sats/vbyte)",
     "refundDate": "Refund Date"
   },
 
@@ -108,6 +110,7 @@
     "oraclePublicKey": "Oracle Public Key",
     "yourCollateral": "Your Collateral",
     "counterpartyCollateral": "Counterparty Collateral",
+    "totalCollateral": "Total Collateral",
     "potentialOutcome": "Potential Outcome",
     "outcomes": "Outcomes",
     "feeRate": "Fee Rate",
@@ -115,7 +118,7 @@
   },
 
   "acceptOfferDescription": {
-    "peerAddress": "Tor address of the person you'd like to complete the contract with"
+    "peerAddress": "Tor address of the person you'd like to complete the contract with.\nPutting an address in here will attempt to complete the remaining contract steps online."
   },
 
   "contracts": {
@@ -176,7 +179,8 @@
     "sendMessageError": {
       "title": "Error sending message to appServer"
     }
-  }
+  },
 
+  "torDLCHostAddress": "Tor DLC Host Address"
 
 }

--- a/wallet-server-ui/src/service/wallet-state-service.ts
+++ b/wallet-server-ui/src/service/wallet-state-service.ts
@@ -2,7 +2,7 @@ import { Injectable } from "@angular/core"
 import { BehaviorSubject } from "rxjs"
 import { BuildConfig } from "~type/proxy-server-types"
 
-import { Balances, BlockchainMessageType, ContractInfo, CoreMessageType, DLCContract, DLCWalletAccounting, FundedAddress, GetInfoResponse, ServerResponse, ServerVersion, WalletMessageType } from "~type/wallet-server-types"
+import { Balances, BlockchainMessageType, ContractInfo, CoreMessageType, DLCContract, DLCMessageType, DLCWalletAccounting, FundedAddress, GetInfoResponse, ServerResponse, ServerVersion, WalletMessageType } from "~type/wallet-server-types"
 import { getMessageBody } from "~util/wallet-server-util"
 
 import { MessageService } from "./message.service"
@@ -19,6 +19,8 @@ export class WalletStateService {
   fundedAddresses: FundedAddress[]
   dlcWalletAccounting: DLCWalletAccounting
   feeEstimate: string
+  torDLCHostAddress: string
+
   dlcs: BehaviorSubject<DLCContract[]> = new BehaviorSubject<DLCContract[]>([])
   contractInfos: BehaviorSubject<{ [dlcId: string]: ContractInfo }> = new BehaviorSubject<{ [dlcId: string]: ContractInfo }>({})
 
@@ -56,7 +58,14 @@ export class WalletStateService {
     })
     this.messageService.sendMessage(getMessageBody(WalletMessageType.estimatefee)).subscribe(r => {
       if (r.result) {
+        // TODO : to number
         this.feeEstimate = r.result
+      }
+    })
+    this.messageService.sendMessage(getMessageBody(DLCMessageType.getdlchostaddress)).subscribe(r => {
+      if (r.result) {
+        this.torDLCHostAddress = r.result
+        console.warn('torDLCHostAddress:', this.torDLCHostAddress)
       }
     })
     this.refreshDLCStates()

--- a/wallet-server-ui/src/service/wallet-state-service.ts
+++ b/wallet-server-ui/src/service/wallet-state-service.ts
@@ -71,7 +71,27 @@ export class WalletStateService {
     this.refreshDLCStates()
   }
 
+  refreshDLCState(dlc: DLCContract) {
+    console.debug('refreshDLCState()', dlc)
+    this.messageService.sendMessage(getMessageBody(WalletMessageType.getdlc, [dlc.dlcId])).subscribe(r => {
+      console.debug('getdlc', r)
+
+      if (r.result) {
+        const dlc = <DLCContract>r.result
+        // Inject in dlcs
+        const i = this.dlcs.value.findIndex(d => d.dlcId === dlc.dlcId)
+        // console.debug('i:', i)
+        if (i !== -1) {
+          const removed = this.dlcs.value.splice(i, 1, dlc)
+          // console.debug('removed:', removed)
+          this.dlcs.next(this.dlcs.value)
+        }
+      }
+    })
+  }
+
   refreshDLCStates() {
+    console.debug('refreshDLCStates()')
     this.messageService.sendMessage(getMessageBody(WalletMessageType.getdlcs)).subscribe(r => {
       if (r.result) {
         this.dlcs.next(r.result)
@@ -88,5 +108,6 @@ export class WalletStateService {
       }
     })
   }
+
 
 }

--- a/wallet-server-ui/src/styles.scss
+++ b/wallet-server-ui/src/styles.scss
@@ -85,4 +85,30 @@ fieldset {
   .pane {
 
   }
+  .left-pane {
+    margin-right: 1rem;
+  }
+  .right-pane {
+    margin-left: 1rem;
+  }
+}
+
+.mat-icon-button {
+  .mat-icon-sm {
+    line-height: 16px;
+  }
+}
+.mat-icon.mat-icon-sm {
+// .mat-mini-fab.mat-icon-sm
+  height: 16px;
+  width: 16px;
+  font-size: 16px;
+  // line-height: 16px;
+}
+
+.mat-mini-fab.mat-fab-sm {
+  // line-height: 24px;
+  // height: 24px;
+  // width: 24px;
+  transform: scale(0.7);
 }

--- a/wallet-server-ui/src/styles.scss
+++ b/wallet-server-ui/src/styles.scss
@@ -117,3 +117,21 @@ fieldset {
   // width: 24px;
   transform: scale(0.7);
 }
+
+.result-group {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  // Cancel default fieldset styling
+  margin: 2rem 0 0 0;
+  padding: 0;
+
+  label {
+    margin-right: 1rem;
+  }
+  .result-textarea {
+    flex: 1;
+
+    // max-width: 20rem;
+  }
+}

--- a/wallet-server-ui/src/styles.scss
+++ b/wallet-server-ui/src/styles.scss
@@ -61,6 +61,11 @@ fieldset {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  align-items: center;
+
+  .section-header-button-group {
+
+  }
 }
 
 .close-button {

--- a/wallet-server-ui/src/type/wallet-server-types.ts
+++ b/wallet-server-ui/src/type/wallet-server-types.ts
@@ -185,6 +185,8 @@ export interface DLCContract {
   state: string // DLCState //  "Offered"
   tempContractId: string // "ddb32c03280b4e064aad9815927f383c87b028a98c07f481e0941624e97d8924"
   totalCollateral: number // 200001
+
+  fundingTxId?: string // not present initially
 }
 
 export enum DLCState {
@@ -231,7 +233,7 @@ export interface Announcement {
 export interface Event {
   eventId: string
   descriptor: EnumEventDescriptor|NumericEventDescriptor
-  nonces: string[]
+  nonces: string[] // nounces.length === descriptor.numDigits
   maturity: string // ISODate like '2030-01-01T00:00:00Z'
 }
 

--- a/wallet-server-ui/src/type/wallet-server-types.ts
+++ b/wallet-server-ui/src/type/wallet-server-types.ts
@@ -192,12 +192,13 @@ export interface DLCContract {
 
   // Claimed
   closingTxId?: string // After executing oracle signatures / Claimed state
+  counterPartyPayout?: number // sats
   myPayout?: number // sats
   oracleSigs?: string[]
   oracles?: string[]
   outcomes?: string|number[][] // for enum, "outcome", for numeric, [[1, 1, 0, 0, 1, 0, 0]]
-  pnl: number // sats
-  rateOfReturn: number // 0.5744851029794041
+  pnl?: number // sats
+  rateOfReturn?: number // 0.5744851029794041
 }
 
 export enum DLCState {
@@ -239,6 +240,7 @@ export interface Announcement {
   announcementSignature: string
   publicKey: string
   event: Event // Announcement
+  hex: string // hex encoding of Announcement
 }
 
 export interface Event {
@@ -301,11 +303,16 @@ export interface FundingInput {
   redeemScript: string|null // null
 }
 
-export interface EnumContractDescriptor { // enum
+export interface ContractDescriptor {
+  // Is this present on all encodings?
+  hex: string // hex encoding of ContractDescriptor
+}
+
+export interface EnumContractDescriptor extends ContractDescriptor { // enum
   outcomes: { [key: string]: number } // outcomes: { YES: 1, NO: 0 }
 }
 
-export interface NumericContractDescriptor {
+export interface NumericContractDescriptor extends ContractDescriptor {
   numDigits: number
   payoutFunction: PayoutFunction
   roundingIntervals: { intervals: unknown[] }

--- a/wallet-server-ui/src/type/wallet-server-types.ts
+++ b/wallet-server-ui/src/type/wallet-server-types.ts
@@ -182,11 +182,22 @@ export interface DLCContract {
   lastUpdated: string // "2021-11-02T18:31:14.789Z"
   localCollateral: number // 100000
   remoteCollateral: number // 100001
-  state: string // DLCState //  "Offered"
+  state: DLCState // string //  "Offered"
   tempContractId: string // "ddb32c03280b4e064aad9815927f383c87b028a98c07f481e0941624e97d8924"
   totalCollateral: number // 200001
 
-  fundingTxId?: string // not present initially
+  // not present initially
+  contractId?: string
+  fundingTxId?: string
+
+  // Claimed
+  closingTxId?: string // After executing oracle signatures / Claimed state
+  myPayout?: number // sats
+  oracleSigs?: string[]
+  oracles?: string[]
+  outcomes?: number[][] // for numeric, [[1, 1, 0, 0, 1, 0, 0]]
+  pnl: number // sats
+  rateOfReturn: number // 0.5744851029794041
 }
 
 export enum DLCState {

--- a/wallet-server-ui/src/type/wallet-server-types.ts
+++ b/wallet-server-ui/src/type/wallet-server-types.ts
@@ -195,7 +195,7 @@ export interface DLCContract {
   myPayout?: number // sats
   oracleSigs?: string[]
   oracles?: string[]
-  outcomes?: number[][] // for numeric, [[1, 1, 0, 0, 1, 0, 0]]
+  outcomes?: string|number[][] // for enum, "outcome", for numeric, [[1, 1, 0, 0, 1, 0, 0]]
   pnl: number // sats
   rateOfReturn: number // 0.5744851029794041
 }

--- a/wallet-server-ui/src/type/wallet-ui-types.ts
+++ b/wallet-server-ui/src/type/wallet-ui-types.ts
@@ -4,6 +4,7 @@ import { Announcement, ContractInfo, Offer } from './wallet-server-types'
 
 // Make these into <T> with hex field?
 
+// TODO : Remove - All Announcements come with hex field now
 export interface AnnouncementWithHex {
   announcement: Announcement
   hex: string // raw hex of Announcement

--- a/wallet-server-ui/src/type/wallet-ui-types.ts
+++ b/wallet-server-ui/src/type/wallet-ui-types.ts
@@ -2,6 +2,8 @@ import { Announcement, ContractInfo, Offer } from './wallet-server-types'
 
 // UI Side types
 
+// Make these into <T> with hex field?
+
 export interface AnnouncementWithHex {
   announcement: Announcement
   hex: string // raw hex of Announcement

--- a/wallet-server-ui/src/util/utils.ts
+++ b/wallet-server-ui/src/util/utils.ts
@@ -16,9 +16,9 @@ export function copyToClipboard(s: string) {
 
 export enum BitcoinNetwork {
   // regtest = 'regtest', // NOT VALIDATED AGAINST BACKEND
-  // signet = 'signet',  // NOT VALIDATED AGAINST BACKEND
   test = 'test',
   main = 'main', // NOT VALIDATED AGAINST BACKEND
+  signet = 'signet', // NOT VALIDATED AGAINST BACKEND
 }
 
 // Network Regex Validators
@@ -70,6 +70,22 @@ export function formatShortHex(s: string|null|undefined) {
   }
   return ''
 }
+
+export function mempoolTransactionURL(txIdHex: string, network: BitcoinNetwork) {
+  switch (network) {
+    case BitcoinNetwork.main:
+      return `https://mempool.space/tx/${txIdHex}`
+    case BitcoinNetwork.test:
+      return `https://mempool.space/testnet/tx/${txIdHex}`
+    case BitcoinNetwork.signet:
+      return `https://mempool.space/signet/tx/${txIdHex}`
+    default:
+      console.error('mempoolTransactionURL() unknown BitcoinNetwork', network)
+      return ''
+  }
+}
+
+// DLCState of DLCContract allow operation functions
 
 export function isCancelable(state: DLCState) {
   return [DLCState.offered, DLCState.accepted, DLCState.signed].includes(state)

--- a/wallet-server-ui/src/util/utils.ts
+++ b/wallet-server-ui/src/util/utils.ts
@@ -76,11 +76,11 @@ export function isCancelable(state: DLCState) {
 }
 
 export function isRefundable(state: DLCState) {
-  return [DLCState.broadcast, DLCState.confirmed].includes(state)
+  return [DLCState.confirmed, DLCState.broadcast, DLCState.confirmed].includes(state)
 }
 
 export function isExecutable(state: DLCState) {
-  return [DLCState.broadcast].includes(state)
+  return [DLCState.confirmed, DLCState.broadcast].includes(state)
 }
 
 export function isFundingTxRebroadcastable(state: DLCState) {

--- a/wallet-server-ui/src/util/utils.ts
+++ b/wallet-server-ui/src/util/utils.ts
@@ -85,6 +85,12 @@ export function mempoolTransactionURL(txIdHex: string, network: BitcoinNetwork) 
   }
 }
 
+const TOR_V3_ADDRESS = /^[a-z2-7]{56}.onion\:\d{4,5}$/;
+
+export function validateTorAddress(address: string) {
+  return TOR_V3_ADDRESS.test(address)
+}
+
 // DLCState of DLCContract allow operation functions
 
 export function isCancelable(state: DLCState) {

--- a/wallet-server-ui/src/util/utils.ts
+++ b/wallet-server-ui/src/util/utils.ts
@@ -1,3 +1,4 @@
+import { DLCState } from "~type/wallet-server-types"
 
 export function copyToClipboard(s: string) {
   const hiddenta = document.createElement('textarea')
@@ -44,3 +45,30 @@ export function formatPercent(num: number, fractionalDigits = 2): string {
   }
   return ''
 }
+
+// Matches upper and lower case hex strings
+const UPPERLOWER_CASE_HEX = /[0-9A-Fa-f]{6}/g;
+
+export function validateHexString(s: string) {
+  return UPPERLOWER_CASE_HEX.test(s)
+}
+
+const SHORT_HEX_LENGTH = 8
+
+export function formatShortHex(s: string|null|undefined) {
+  if (s) {
+    if (s.length < SHORT_HEX_LENGTH) return s
+    return s.substring(0, SHORT_HEX_LENGTH) + '...' // this.translate('unit.ellipsis')
+  }
+  return ''
+}
+
+export function isCancelable(state: DLCState) {
+  return [DLCState.offered, DLCState.accepted, DLCState.signed].includes(state)
+}
+
+export function isRefundable(state: DLCState) {
+  return [DLCState.broadcast, DLCState.confirmed].includes(state)
+}
+
+

--- a/wallet-server-ui/src/util/utils.ts
+++ b/wallet-server-ui/src/util/utils.ts
@@ -47,6 +47,13 @@ export function formatDateTime(dateTime: number) {
   return new Date(dateTime * 1000).toLocaleDateString()
 }
 
+// From common-ts
+export function dateToSecondsSinceEpoch(date: Date) {
+  const secondsSinceEpoch = Math.round(date.getTime() / 1000)
+  return secondsSinceEpoch
+}
+
+
 export function formatPercent(num: number, fractionalDigits = 2): string {
   if (num !== undefined) {
     return (num * 100).toFixed(fractionalDigits)

--- a/wallet-server-ui/src/util/utils.ts
+++ b/wallet-server-ui/src/util/utils.ts
@@ -37,3 +37,10 @@ export function validateBitcoinAddress(network: string, address: string) {
   }
   return false
 }
+
+export function formatPercent(num: number, fractionalDigits = 2): string {
+  if (num !== undefined) {
+    return num.toFixed(fractionalDigits)
+  }
+  return ''
+}

--- a/wallet-server-ui/src/util/utils.ts
+++ b/wallet-server-ui/src/util/utils.ts
@@ -39,9 +39,17 @@ export function validateBitcoinAddress(network: string, address: string) {
   return false
 }
 
+export function formatISODate(isoDate: string) {
+  return new Date(isoDate).toLocaleDateString()
+}
+
+export function formatDateTime(dateTime: number) {
+  return new Date(dateTime * 1000).toLocaleDateString()
+}
+
 export function formatPercent(num: number, fractionalDigits = 2): string {
   if (num !== undefined) {
-    return num.toFixed(fractionalDigits)
+    return (num * 100).toFixed(fractionalDigits)
   }
   return ''
 }
@@ -71,4 +79,10 @@ export function isRefundable(state: DLCState) {
   return [DLCState.broadcast, DLCState.confirmed].includes(state)
 }
 
+export function isExecutable(state: DLCState) {
+  return [DLCState.broadcast].includes(state)
+}
 
+export function isFundingTxRebroadcastable(state: DLCState) {
+  return [DLCState.broadcast].includes(state)
+}

--- a/wallet-server-ui/src/util/utils.ts
+++ b/wallet-server-ui/src/util/utils.ts
@@ -43,6 +43,7 @@ export function formatISODate(isoDate: string) {
   return new Date(isoDate).toLocaleDateString()
 }
 
+// units epochSeconds?
 export function formatDateTime(dateTime: number) {
   return new Date(dateTime * 1000).toLocaleDateString()
 }

--- a/wallet-ts/lib/index.ts
+++ b/wallet-ts/lib/index.ts
@@ -11,7 +11,7 @@ import { BlockchainMessageType, BlockHeaderResponse, GetInfoResponse } from './t
 import { Announcement, Attestment, CoreMessageType, Offer } from './type/core-types'
 import { DLCMessageType } from './type/dlc-types'
 import { NetworkMessageType } from './type/network-types'
-import { AddressInfo, Balances, DLCWalletAccounting, FundedAddress, Outpoint, UTXO, WalletInfo, WalletMessageType } from './type/wallet-types'
+import { AddressInfo, Balances, DLCContract, DLCWalletAccounting, FundedAddress, Outpoint, UTXO, WalletInfo, WalletMessageType } from './type/wallet-types'
 
 // Expose all 'common' endpoints
 export * from '../../common-ts/lib/index';
@@ -173,14 +173,22 @@ export function GetBalances(inSats: boolean) {
 }
 
 // Should it be possible to create a new address without a label?
-export function GetNewAddress(label: string) {
+export function GetNewAddress(label?: string) {
   console.debug('GetNewAddress()', label)
-  validateString(label, 'GetNewAddress()', 'label')
 
-  const m = getMessageBody(WalletMessageType.getnewaddress, [label])
-  return SendServerMessage(m).then(response => {
-    return <ServerResponse<string>>response
-  })
+  if (label !== undefined) {
+    validateString(label, 'GetNewAddress()', 'label')
+
+    const m = getMessageBody(WalletMessageType.getnewaddress, [label])
+    return SendServerMessage(m).then(response => {
+      return <ServerResponse<string>>response
+    })
+  } else {
+    const m = getMessageBody(WalletMessageType.getnewaddress)
+    return SendServerMessage(m).then(response => {
+      return <ServerResponse<string>>response
+    })
+  }
 }
 
 export function GetTransaction(sha256hash: string) {
@@ -200,6 +208,7 @@ export function LockUnspent(unlock: boolean, outPoints: any[]) {
 
   const m = getMessageBody(WalletMessageType.lockunspent, [unlock, outPoints])
   return SendServerMessage(m).then(response => {
+    // boolean value === ?
     return <ServerResponse<boolean>>response
   })
 }
@@ -276,7 +285,7 @@ export function GetDLCs() {
 
   const m = getMessageBody(WalletMessageType.getdlcs)
   return SendServerMessage(m).then(response => {
-    return <ServerResponse<unknown[]>>response
+    return <ServerResponse<DLCContract[]>>response
   })
 }
 
@@ -285,7 +294,7 @@ export function GetDLC(sha256hash: string) {
 
   const m = getMessageBody(WalletMessageType.getdlc, [sha256hash])
   return SendServerMessage(m).then(response => {
-    return <ServerResponse<unknown>>response
+    return <ServerResponse<DLCContract>>response
   })
 }
 
@@ -679,7 +688,8 @@ export function SendRawTransaction(hex: string) {
 
   const m = getMessageBody(WalletMessageType.sendrawtransaction, [hex])
   return SendServerMessage(m).then(response => {
-    return <ServerResponse<unknown>>response
+    // Returns txId
+    return <ServerResponse<string>>response
   })
 }
 

--- a/wallet-ts/lib/index.ts
+++ b/wallet-ts/lib/index.ts
@@ -496,6 +496,7 @@ export function SweepWallet(address: string, satsPerVByte: number) {
 
   const m = getMessageBody(WalletMessageType.dropaddresslabels, [address])
   return SendServerMessage(m).then(response => {
+    // tx.txIdBE from WalletRoutes.scal ? Should this really be the return type?
     return <ServerResponse<unknown>>response
   })
 }

--- a/wallet-ts/lib/type/core-types.ts
+++ b/wallet-ts/lib/type/core-types.ts
@@ -79,14 +79,19 @@ export interface FundingInput {
   redeemScript: string|null // null
 }
 
-export interface EnumContractDescriptor { // enum
+export interface ContractDescriptor {
+  // Is this present on all encodings?
+  hex: string // hex encoding of ContractDescriptor
+}
+
+export interface EnumContractDescriptor extends ContractDescriptor { // enum
   outcomes: { [key: string]: number } // outcomes: { YES: 1, NO: 0 }
 }
 
-export interface NumericContractDescriptor {
+export interface NumericContractDescriptor extends ContractDescriptor {
   numDigits: number
   payoutFunction: PayoutFunction
-  roundingIntervals: { intervals: unknown[] }
+  roundingIntervals: { intervals: unknown[] } // TODO : Type me
 }
 
 export interface PayoutFunction {

--- a/wallet-ts/lib/type/core-types.ts
+++ b/wallet-ts/lib/type/core-types.ts
@@ -21,6 +21,7 @@ export interface Announcement {
   announcementSignature: string
   publicKey: string
   event: Event // Announcement
+  hex: string // hex encoding of Announcement
 }
 
 export interface Event {

--- a/wallet-ts/lib/type/wallet-types.ts
+++ b/wallet-ts/lib/type/wallet-types.ts
@@ -129,9 +129,31 @@ export interface DLCContract {
   state: string // DLCState //  "Offered"
   tempContractId: string // "ddb32c03280b4e064aad9815927f383c87b028a98c07f481e0941624e97d8924"
   totalCollateral: number // 200001
+
+  // not present initially
+  contractId?: string
+  fundingTxId?: string
+
+  // Claimed
+  closingTxId?: string // After executing oracle signatures / Claimed state
+  myPayout?: number // sats
+  oracleSigs?: string[]
+  oracles?: string[]
+  outcomes?: number[][] // for numeric, [[1, 1, 0, 0, 1, 0, 0]]
+  pnl: number // sats
+  rateOfReturn: number // 0.5744851029794041
 }
 
 export enum DLCState {
-  offered = "Offered",
-
+  // InProgressState
+  offered = 'Offered',
+  accepted = 'Accepted',
+  signed = 'Signed',
+  broadcast = 'Broadcasted',
+  confirmed = 'Confirmed',
+  // ClosedViaOracleOutcomeState
+  claimed = 'Claimed',
+  remoteClaimed = 'RemoteClaimed',
+  // ClosedState
+  refunded = 'Refunded',
 }

--- a/wallet-ts/lib/type/wallet-types.ts
+++ b/wallet-ts/lib/type/wallet-types.ts
@@ -136,12 +136,13 @@ export interface DLCContract {
 
   // Claimed
   closingTxId?: string // After executing oracle signatures / Claimed state
+  counterPartyPayout?: number // sats
   myPayout?: number // sats
   oracleSigs?: string[]
   oracles?: string[]
   outcomes?: string|number[][] // for enum, "outcome", for numeric, [[1, 1, 0, 0, 1, 0, 0]]
-  pnl: number // sats
-  rateOfReturn: number // 0.5744851029794041
+  pnl?: number // sats
+  rateOfReturn?: number // 0.5744851029794041
 }
 
 export enum DLCState {

--- a/wallet-ts/lib/type/wallet-types.ts
+++ b/wallet-ts/lib/type/wallet-types.ts
@@ -139,7 +139,7 @@ export interface DLCContract {
   myPayout?: number // sats
   oracleSigs?: string[]
   oracles?: string[]
-  outcomes?: number[][] // for numeric, [[1, 1, 0, 0, 1, 0, 0]]
+  outcomes?: string|number[][] // for enum, "outcome", for numeric, [[1, 1, 0, 0, 1, 0, 0]]
   pnl: number // sats
   rateOfReturn: number // 0.5744851029794041
 }

--- a/wallet-ts/test/basic-tests.ts
+++ b/wallet-ts/test/basic-tests.ts
@@ -63,10 +63,10 @@ export async function basicTests() {
     assert.ifError(r.error)
   })
 
-  await WalletServer.LockUnspent(true, []).then(r => {
-    console.debug('LockUnspent()', r)
-    assert.ifError(r.error)
-  })
+  // await WalletServer.LockUnspent(true, []).then(r => {
+  //   console.debug('LockUnspent()', r)
+  //   assert.ifError(r.error)
+  // })
 
   const TEST_LABEL = 'test'
   const TEST_LABEL_2 = 'test label'


### PR DESCRIPTION
Third edition of wallet UI. Supports acceptdlcoffer via Tor for both contract types. Enables a number of other contract interactions like cancel, execute, rebroadcast funding txs. Add number and date formatting, unit labels, payouts on new offers. Handles ContractInfo hex to instantiate Build Offer, but doesn't execute yet. Adds MAX button to sending funds, but underlying sweep functionality is untested.

Currently cannot execute a DLC and have wallet in good state due to bitcoin-s/bitcoin-s#3826.

![Screen Shot 2021-11-16 at 8 47 49 AM](https://user-images.githubusercontent.com/22351459/142018189-0fe68f41-c18c-4f22-bbfd-837c11973f86.png)

![Screen Shot 2021-11-16 at 8 48 41 AM](https://user-images.githubusercontent.com/22351459/142018388-cc574491-b10e-483a-8a09-0abd4a0db7a5.png)

![Screen Shot 2021-11-16 at 8 48 15 AM](https://user-images.githubusercontent.com/22351459/142018414-07b5805e-98a2-4202-9668-1f935ab6f9a0.png)
