### PR TITLE
Add payout graphs

### DIFF
--- a/wallet-server-ui/package-lock.json
+++ b/wallet-server-ui/package-lock.json
@@ -20,7 +20,9 @@
         "@angular/router": "~12.2.0",
         "@ngx-translate/core": "^13.0.0",
         "@ngx-translate/http-loader": "^6.0.0",
+        "chart.js": "^3.7.0",
         "file-saver": "^2.0.5",
+        "ng2-charts": "^3.0.8",
         "rxjs": "~6.6.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.11.4"
@@ -3724,6 +3726,11 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "node_modules/chart.js": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.7.0.tgz",
+      "integrity": "sha512-31gVuqqKp3lDIFmzpKIrBeum4OpZsQjSIAqlOpgjosHDJZlULtvwLEZKtEhIAZc7JMPaHlYMys40Qy9Mf+1AAg=="
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
@@ -8426,6 +8433,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -9201,6 +9213,21 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/ng2-charts": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-3.0.8.tgz",
+      "integrity": "sha512-ELlpN0b/IJO4ka/P2sFBKeng3bV7XOQuh40f0J5hx9UveWPaSxOYQAOiGxV7BN2VSnKq6GRkjRvqTrcQPyJYww==",
+      "dependencies": {
+        "lodash-es": "^4.17.15",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=11.0.0",
+        "@angular/core": ">=11.0.0",
+        "chart.js": "^3.4.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
     },
     "node_modules/nice-napi": {
       "version": "1.0.2",
@@ -18506,6 +18533,11 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "chart.js": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.7.0.tgz",
+      "integrity": "sha512-31gVuqqKp3lDIFmzpKIrBeum4OpZsQjSIAqlOpgjosHDJZlULtvwLEZKtEhIAZc7JMPaHlYMys40Qy9Mf+1AAg=="
+    },
     "chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -22068,6 +22100,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -22669,6 +22706,15 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "ng2-charts": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-3.0.8.tgz",
+      "integrity": "sha512-ELlpN0b/IJO4ka/P2sFBKeng3bV7XOQuh40f0J5hx9UveWPaSxOYQAOiGxV7BN2VSnKq6GRkjRvqTrcQPyJYww==",
+      "requires": {
+        "lodash-es": "^4.17.15",
+        "tslib": "^2.3.0"
+      }
     },
     "nice-napi": {
       "version": "1.0.2",

--- a/wallet-server-ui/package.json
+++ b/wallet-server-ui/package.json
@@ -23,7 +23,9 @@
     "@angular/router": "~12.2.0",
     "@ngx-translate/core": "^13.0.0",
     "@ngx-translate/http-loader": "^6.0.0",
+    "chart.js": "^3.7.0",
     "file-saver": "^2.0.5",
+    "ng2-charts": "^3.0.8",
     "rxjs": "~6.6.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"

--- a/wallet-server-ui/src/app/app.module.ts
+++ b/wallet-server-ui/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { APP_INITIALIZER, NgModule } from '@angular/core'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 import { BrowserModule } from '@angular/platform-browser'
+import { NgChartsModule } from 'ng2-charts'
 import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core'
 import { TranslateHttpLoader } from '@ngx-translate/http-loader'
 
@@ -95,6 +96,7 @@ export function appInitializerFactory(translate: TranslateService) {
       }
     }),
     MaterialModule,
+    NgChartsModule,
     AppRoutingModule,
   ],
   providers: [{

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
@@ -77,6 +77,15 @@
             <input class="endpoint-checkbox" type="checkbox" [checked]="point.isEndpoint" disabled>
           </div>
         </div>
+
+        <div class="vspacer-1"></div>
+
+        <canvas baseChart
+          [data]="chartData"
+          [options]="chartOptions"
+          [type]="'scatter'">
+        </canvas>
+       
       </div>
 
       <div class="vspacer-2"></div>

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.ts
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.ts
@@ -1,8 +1,10 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core'
+import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core'
 import { AbstractControl, FormBuilder, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms'
 import { MatDialog } from '@angular/material/dialog'
 import { MatRadioChange } from '@angular/material/radio'
+import { ChartData, ChartOptions } from 'chart.js'
 import { TranslateService } from '@ngx-translate/core'
+import { BaseChartDirective } from 'ng2-charts'
 import * as FileSaver from 'file-saver'
 
 import { MessageService } from '~service/message.service'
@@ -45,6 +47,8 @@ export class AcceptOfferComponent implements OnInit {
   public copyToClipboard = copyToClipboard
   public formatNumber = formatNumber
 
+  @ViewChild(BaseChartDirective) chart: BaseChartDirective
+
   private _offer: OfferWithHex
   @Input() set offer (offer: OfferWithHex) {
     this._offer = offer
@@ -83,6 +87,34 @@ export class AcceptOfferComponent implements OnInit {
   maturityDate: string
   refundDate: string
 
+  chartData: ChartData<'scatter'> = {
+    datasets: [{
+      data: [],
+      label: 'Payout',
+      // Purple
+      backgroundColor: 'rgb(125,79,194)',
+      borderColor: 'rgb(125,79,194)',
+      // Suredbits blue offset
+      pointHoverBackgroundColor: 'rgb(131,147,156)',
+      pointHoverBorderColor: 'rgb(131,147,156)',
+      pointHoverRadius: 8,
+      fill: false,
+      tension: 0,
+      showLine: true,
+    }]
+  }
+  chartOptions: ChartOptions = {
+    responsive: true
+  }
+  updateChartData() {
+    const data = []
+    for (const p of this.numericContractDescriptor.payoutFunction.points) {
+      // Inverting payout values
+      data.push({ x: p.outcome, y: this.contractInfo.totalCollateral - p.payout })
+    }
+    this.chartData.datasets[0].data = data
+  }
+
   acceptOfferTypes = [AcceptOfferType.TOR, AcceptOfferType.FILES]
   acceptOfferType = AcceptOfferType.TOR
   updateAcceptOfferType(event: MatRadioChange) {
@@ -111,6 +143,10 @@ export class AcceptOfferComponent implements OnInit {
         filename: this.defaultFilename
       })
       this.form.markAsUntouched()
+    }
+
+    if (this.numericContractDescriptor) {
+      this.updateChartData()
     }
   }
 

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -100,6 +100,15 @@
           <input class="outcome-payout text-right" [value]="getOutcomeValue( p.payout )" disabled>
           <input type="checkbox" [checked]="p.isEndpoint" disabled>
         </div>
+
+        <div class="vspacer-1"></div>
+
+        <canvas baseChart
+          [data]="chartData"
+          [options]="chartOptions"
+          [type]="'scatter'">
+        </canvas>
+
       </div>
       <ng-container *ngIf="outcome">
         <mat-form-field class="w-100">

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
@@ -1,9 +1,10 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core'
+import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core'
 import { FormBuilder, FormGroup, Validators } from '@angular/forms'
 import { MatDialog } from '@angular/material/dialog'
 import { MatSnackBar } from '@angular/material/snack-bar'
-import { TranslateService } from '@ngx-translate/core'
 import * as FileSaver from 'file-saver'
+import { TranslateService } from '@ngx-translate/core'
+import { BaseChartDirective } from 'ng2-charts'
 import { of } from 'rxjs'
 import { catchError } from 'rxjs/operators'
 
@@ -17,6 +18,7 @@ import { Attestment, ContractDescriptor, ContractInfo, CoreMessageType, DLCContr
 import { AcceptWithHex, SignWithHex } from '~type/wallet-ui-types'
 import { copyToClipboard, formatDateTime, formatISODate, formatNumber, formatPercent, isCancelable, isExecutable, isFundingTxRebroadcastable, isRefundable, outcomeDigitsToNumber, validateHexString } from '~util/utils'
 import { getMessageBody } from '~util/wallet-server-util'
+import { ChartData, ChartOptions } from 'chart.js'
 
 
 @Component({
@@ -37,6 +39,8 @@ export class ContractDetailComponent implements OnInit {
   public isExecutable = isExecutable
   public isFundingTxRebroadcastable = isFundingTxRebroadcastable
 
+  @ViewChild(BaseChartDirective) chart: BaseChartDirective
+
   _dlc!: DLCContract
   get dlc(): DLCContract { return this._dlc }
   @Input() set dlc(e: DLCContract) { 
@@ -49,6 +53,7 @@ export class ContractDetailComponent implements OnInit {
   @Input() set contractInfo(e: ContractInfo) {
     this._contractInfo = e
     this.setOutcome(e)
+    this.updateChartData()
   }
 
   private setOutcome(contractInfo: ContractInfo) {
@@ -59,7 +64,9 @@ export class ContractDetailComponent implements OnInit {
       } else { // this.isNumeric()
         if (this.dlc.outcomes.length > 0 && this.dlc.outcomes[0]) {
           const digits = <number[]>this.dlc.outcomes[0]
-          outcome = outcomeDigitsToNumber(digits).toString()
+          const numericOutcome = outcomeDigitsToNumber(digits)
+          outcome = numericOutcome.toString()
+          this.outcomePoint = { x: numericOutcome, y: this.dlc.myPayout }
         }
       }
     }
@@ -98,6 +105,63 @@ export class ContractDetailComponent implements OnInit {
   contractMaturity: string
   contractTimeout: string
   outcome: string
+  outcomePoint: any
+
+  chartData: ChartData<'scatter'> = {
+    datasets: [{
+      data: [],
+      label: 'Payout',
+      // Purple
+      backgroundColor: 'rgb(125,79,194)',
+      borderColor: 'rgb(125,79,194)',
+      // Suredbits blue offset
+      pointHoverBackgroundColor: 'rgb(131,147,156)',
+      pointHoverBorderColor: 'rgb(131,147,156)',
+      pointHoverRadius: 8,
+      fill: false,
+      tension: 0,
+      showLine: true,
+    }, ]
+  }
+  chartOptions: ChartOptions = {
+    responsive: true
+  }
+  chartDataOutcome: any = {
+    data: [],
+    label: 'Outcome',
+    // Suredbits Orange
+    backgroundColor: 'rgb(236,73,58)',
+    borderColor: 'rgb(236,73,58)',
+    // Suredbits Orange offset
+    pointHoverBackgroundColor: 'rgb(244,154,140)',
+    pointHoverBorderColor: 'rgb(244,154,140)',
+    fill: false,
+    tension: 0,
+    showLine: false,
+    pointRadius: 5,
+    pointHoverRadius: 8,
+  }
+  updateChartData() {
+    if (this.isNumeric()) {
+      const data = []
+      for (const p of this.getNumericContractDescriptor().payoutFunction.points) {
+        if (this.dlc.isInitiator) {
+          data.push({ x: p.outcome, y: p.payout })
+        } else {
+          data.push({ x: p.outcome, y: this.dlc.totalCollateral - p.payout })
+        }
+      }
+      this.chartData.datasets[0].data = data
+      // TODO : Label the outcome differently
+      if (this.outcomePoint) {
+        this.chartDataOutcome.data = [this.outcomePoint]
+        this.chartData.datasets[1] = this.chartDataOutcome
+      }
+      if (this.chart) {
+        this.chart.chart?.update()
+      }
+    }
+  }
 
   private reset() {
     if (this.dlc) {

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
@@ -52,25 +52,22 @@ export class ContractDetailComponent implements OnInit {
   get contractInfo(): ContractInfo { return this._contractInfo }
   @Input() set contractInfo(e: ContractInfo) {
     this._contractInfo = e
-    this.setOutcome(e)
-    this.updateChartData()
   }
 
   private setOutcome(contractInfo: ContractInfo) {
     let outcome = ''
     if (contractInfo && this.dlc.outcomes) {
-      if ((<EnumContractDescriptor>contractInfo.contractDescriptor).outcomes !== undefined) { // this.isEnum()
+      if (this.isEnum()) {
         outcome = <string>this.dlc.outcomes
       } else { // this.isNumeric()
-        if (this.dlc.outcomes.length > 0 && this.dlc.outcomes[0]) {
-          const digits = <number[]>this.dlc.outcomes[0]
-          const numericOutcome = outcomeDigitsToNumber(digits)
+        if (this.dlc.outcomes.length > 0 && Array.isArray(this.dlc.outcomes[0])) {
+          const numericOutcome = outcomeDigitsToNumber(<number[]>[...this.dlc.outcomes[0]])
           outcome = numericOutcome.toString()
           this.outcomePoint = { x: numericOutcome, y: this.dlc.myPayout }
         }
       }
     }
-    console.debug('getOutcome()', outcome)
+    console.debug('setOutcome()', outcome)
     this.outcome = outcome
   }
 
@@ -169,8 +166,9 @@ export class ContractDetailComponent implements OnInit {
       this.contractTimeout = formatDateTime(this.dlc.contractTimeout)
       this.oracleAttestations = this.dlc.oracleSigs?.toString() || ''
     } else {
-      this.oracleAttestations = ''
+      this.contractMaturity = ''
       this.contractTimeout = ''
+      this.oracleAttestations = ''
     }
     this.outcome = ''
   }
@@ -195,6 +193,9 @@ export class ContractDetailComponent implements OnInit {
     this.form = this.formBuilder.group({
       filename: [this.defaultFilename, Validators.required],
     })
+    // These need to occur after dlc and contractInfo have both set
+    this.setOutcome(this.contractInfo)
+    this.updateChartData()
   }
 
   onClose() {

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.ts
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.ts
@@ -42,7 +42,7 @@ export class ContractsComponent implements OnInit, AfterViewInit, OnDestroy {
   //   console.debug('clearSelection()')
   //   this.selectedDLCContract = <DLCContract><unknown>null
   // }
-  @Output() selectedDLC: EventEmitter<DLCContractInfo> = new EventEmitter()
+  // @Output() selectedDLC: EventEmitter<DLCContractInfo> = new EventEmitter()
 
   // Grid config
   dataSource = new MatTableDataSource(<DLCContract[]>[])
@@ -167,10 +167,10 @@ export class ContractsComponent implements OnInit, AfterViewInit, OnDestroy {
 
     this.selectedDLCContract = dlcContract
     this.selectedDLCContractInfo = this.walletStateService.contractInfos.value[dlcContract.dlcId]
-    this.selectedDLC.emit(<DLCContractInfo>{
-      dlc: dlcContract,
-      contractInfo: this.selectedDLCContractInfo,
-    })
+    // this.selectedDLC.emit(<DLCContractInfo>{
+    //   dlc: dlcContract,
+    //   contractInfo: this.selectedDLCContractInfo,
+    // })
 
     this.contractDetailsVisible = true
     this.rightDrawer.open()

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
@@ -135,6 +135,14 @@
           </mat-expansion-panel>
         </mat-accordion>
         -->
+
+        <div class="vspacer-1"></div>
+
+        <canvas baseChart
+          [data]="chartData"
+          [options]="chartOptions"
+          [type]="'scatter'">
+        </canvas>
       </div>
 
       <ng-container *ngIf="payoutInputsInvalid">

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -5,7 +5,7 @@
 
   "splashScreen": {
     "heading": "Welcome to the Suredbits Wallet",
-    "betaSoftware": "This application is beta software.",
+    "betaSoftware": "This application is alpha software.",
     "significantValue": "Please do not use it with significant amounts of value at this time.",
     "caveatEmptor": "caveat emptor",
     "dontShowSplashAgain": "Don't show this screen again"


### PR DESCRIPTION
This adds payout graphs using the same chart.js library used on the Oracle Explorer. There are probably better options to think about long term, but this gets the feature in and working. Graphs live update as the user edits a numeric offer and render accepting the offer and show outcome if one exists on contract details.
![Screen Shot 2022-01-30 at 9 51 42 AM](https://user-images.githubusercontent.com/22351459/151709304-994ed7f0-06fe-4348-9a75-f1839715df17.png)
![Screen Shot 2022-01-30 at 9 51 55 AM](https://user-images.githubusercontent.com/22351459/151709309-5a94a35a-67c3-485f-94c1-fd8eadf121d4.png)
![Screen Shot 2022-01-30 at 9 53 02 AM](https://user-images.githubusercontent.com/22351459/151709313-f801c057-30fe-4e26-877b-1b4a90ba6313.png)

