### PR TITLE
Bump docker publish timeout to 90 minutes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v2.3.4


### PR DESCRIPTION
We are seeing builds timeout when publishing to docker so bump the timeout for now as a stop gap. Over the long term we should look for a away to optimize the build.

https://github.com/bitcoin-s/bitcoin-s-ts/runs/5022835894?check_suite_focus=true#step:10:333

