### PR TITLE
Add unit labels to dlc views

### DIFF
--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
@@ -47,6 +47,7 @@
 
       <div *ngIf="isEnum()" class="enum-offer">
         <label class="mat-form-label" translate>acceptOffer.payouts</label>
+        <!-- TODO : Use grid -->
         <div class="outcome-group">
           <div class="enum-payout-group">
             <div class="icon-spacer"></div>
@@ -57,11 +58,13 @@
           <div *ngFor="let label of Object.keys(enumContractDescriptor.outcomes)" class="enum-payout-group">
             <label class="outcome-label text-right">{{ label }}</label>
             <input class="outcome-value text-right" type="number" [value]="contractInfo.totalCollateral - enumContractDescriptor.outcomes[label]" readonly>
+            <span class="unit" translate>unit.sats</span>
           </div>
         </div>
       </div>
       <div *ngIf="isNumeric()" class="numeric-offer">
         <label class="mat-form-label" translate>acceptOffer.payoutCurve</label>
+        <!-- TODO : Use grid -->
         <div class="outcome-group">
           <div class="numeric-payout-group">
             <div class="icon-spacer"></div>
@@ -69,6 +72,11 @@
             <label class="payout-heading text-center" translate>newOffer.payout</label>
             <label class="endpoint-heading text-center" translate>newOffer.endpoint</label>
             <app-more-info matSuffix tooltip="newOfferDescription.outcomes"></app-more-info>
+          </div>
+          <div class="numeric-payout-group">
+            <label class="outcome-heading text-center">{{ units }}</label>
+            <label class="payout-heading text-center" translate>unit.satoshis</label>
+            <div class="rem4-spacer"></div>
           </div>
           <div *ngFor="let point of numericContractDescriptor.payoutFunction.points; let i = index"
             class="numeric-payout-group">

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.scss
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.scss
@@ -15,6 +15,7 @@
         width: 100%;
 
         margin-bottom: 0.25rem;
+        
         &:first-of-type {
           min-height: 40px;
           margin-bottom: 0.5rem;
@@ -22,6 +23,9 @@
 
         .icon-spacer {
           width: 24px;
+        }
+        .rem4-spacer {
+          width: 4rem;
         }
         label {
           display: inline-block;
@@ -47,6 +51,9 @@
         }
         .outcome-value {
           width: 8rem;
+        }
+        .unit {
+          margin-left: 0.25rem;
         }
       }
 

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.ts
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.ts
@@ -90,6 +90,7 @@ export class AcceptOfferComponent implements OnInit {
 
   maturityDate: string
   refundDate: string
+  units: string
 
   chartData: ChartData<'scatter'>
   chartOptions: ChartOptions
@@ -97,8 +98,8 @@ export class AcceptOfferComponent implements OnInit {
   buildChart() {
     if (this.isNumeric()) {
       this.chartData = this.chartService.getChartData()
-      const unit = (<NumericEventDescriptor>this.contractInfo.oracleInfo.announcement.event.descriptor).unit
-      this.chartOptions = this.chartService.getChartOptions(unit)
+      
+      this.chartOptions = this.chartService.getChartOptions(this.units)
       this.updateChartData()
     }
   }
@@ -134,6 +135,11 @@ export class AcceptOfferComponent implements OnInit {
   private reset() {
     this.maturityDate = formatISODateTime(this.event.maturity)
     this.refundDate = formatDateTime(this.offer.offer.refundLocktime)
+    if (this.isNumeric()) {
+      this.units = (<NumericEventDescriptor>this.contractInfo.oracleInfo.announcement.event.descriptor).unit
+    } else {
+      this.units = ''
+    }
     this.acceptOfferType = AcceptOfferType.TOR
     this.result = ''
     this.executing = false

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -82,6 +82,7 @@
       <!-- Enum / Numeric Outcomes -->
       <div *ngIf="isEnum()" class="enum-outcomes">
         <label class="mat-form-label" translate>contractDetail.outcomePayouts</label>
+        <!-- TODO : Use grid -->
         <div class="enum-group" *ngFor="let l of Object.keys(getEnumContractDescriptor().outcomes)">
           <label class="outcome-label">{{ l }}</label>
           <input class="outcome-payout text-right" [value]="getOutcomeValue( getEnumContractDescriptor().outcomes[l] )" disabled>
@@ -90,10 +91,15 @@
       </div>
       <div *ngIf="isNumeric()" class="numeric-outcomes">
         <label class="mat-form-label" translate>contractDetail.payoutCurve</label>
+        <!-- TODO : Use grid -->
         <div class="numeric-group heading-group">
           <label class="outcome-heading text-center" translate>newOffer.outcome</label>
           <label class="payout-heading text-center" translate>newOffer.payout</label>
           <label class="endpoint-heading text-center" translate>newOffer.endpoint</label>
+        </div>
+        <div class="numeric-group">
+          <label class="outcome-heading text-center">{{ units }}</label>
+          <label class="payout-heading text-center" translate>unit.satoshis</label>
         </div>
         <div class="numeric-group" *ngFor="let p of getNumericContractDescriptor().payoutFunction.points">
           <label class="outcome-label">{{ p.outcome }}</label>
@@ -111,9 +117,10 @@
 
       </div>
       <ng-container *ngIf="outcome">
-        <mat-form-field class="w-100">
+        <mat-form-field>
           <mat-label translate>contractDetail.outcome</mat-label>
           <input matInput [value]="outcome" readonly>
+          <span matSuffix translate>unit.sats</span>
         </mat-form-field>
       </ng-container>
 

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -120,7 +120,7 @@
         <mat-form-field>
           <mat-label translate>contractDetail.outcome</mat-label>
           <input matInput [value]="outcome" readonly>
-          <span matSuffix translate>unit.sats</span>
+          <span *ngIf="isNumeric()" matSuffix>{{ units }}</span>
         </mat-form-field>
       </ng-container>
 

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.scss
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.scss
@@ -72,7 +72,11 @@
       }
     }
     .heading-group {
-      margin-bottom: 0.5rem;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      width: 100%;
+      min-height: 40px;
     }
   }
 

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
@@ -92,9 +92,9 @@ export class ContractDetailComponent implements OnInit {
     }
   }
 
-  private setOutcome(contractInfo: ContractInfo) {
+  private setOutcome() {
     let outcome = ''
-    if (contractInfo && this.dlc.outcomes) {
+    if (this.contractInfo && this.dlc.outcomes) {
       if (this.isEnum()) {
         outcome = <string>this.dlc.outcomes
       } else { // this.isNumeric()
@@ -138,7 +138,6 @@ export class ContractDetailComponent implements OnInit {
       this.chartData = this.chartService.getChartData()
       const unit = (<NumericEventDescriptor>this.contractInfo.oracleInfo.announcement.event.descriptor).unit
       this.chartOptions = this.chartService.getChartOptions(unit)
-      this.setOutcome(this.contractInfo)
       this.updateChartData()
     }
   }
@@ -197,6 +196,7 @@ export class ContractDetailComponent implements OnInit {
     this.form = this.formBuilder.group({
       filename: [this.defaultFilename, Validators.required],
     })
+    this.setOutcome()
     this.buildChart()
     this.darkModeService.darkModeChanged.subscribe(() => this.buildChart()) // this doesn't always seem to be necessary, but here to protect us
   }

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
@@ -56,15 +56,16 @@ export class ContractDetailComponent implements OnInit {
   get contractInfo(): ContractInfo { return this._contractInfo }
   @Input() set contractInfo(e: ContractInfo) {
     this._contractInfo = e
+    this.setUnits()
   }
 
   isEnum() {
-    const cd = <EnumContractDescriptor><unknown>this.contractInfo.contractDescriptor
+    const cd = <EnumContractDescriptor>this.contractInfo.contractDescriptor
     return cd.outcomes !== undefined
   }
 
   isNumeric() {
-    const cd = <NumericContractDescriptor><unknown>this.contractInfo.contractDescriptor
+    const cd = <NumericContractDescriptor>this.contractInfo.contractDescriptor
     return cd.numDigits !== undefined
   }
 
@@ -81,6 +82,14 @@ export class ContractDetailComponent implements OnInit {
       return <EnumContractDescriptor>this.contractInfo.contractDescriptor
     else // if (this.isNumeric())
       return <NumericContractDescriptor>this.contractInfo.contractDescriptor
+  }
+
+  private setUnits() {
+    if (this.isNumeric()) {
+      this.units = (<NumericEventDescriptor>this.contractInfo.oracleInfo.announcement.event.descriptor).unit
+    } else {
+      this.units = ''
+    }
   }
 
   private setOutcome(contractInfo: ContractInfo) {
@@ -112,9 +121,10 @@ export class ContractDetailComponent implements OnInit {
 
   @Output() close: EventEmitter<void> = new EventEmitter()
 
-  oracleAttestations: string // OracleAttestmentTLV
   contractMaturity: string
   contractTimeout: string
+  units: string
+  oracleAttestations: string // OracleAttestmentTLV
 
   outcome: string
   outcomePoint: any

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
@@ -57,6 +57,7 @@
 
       <ng-container *ngIf="isEnum()">
         <label class="mat-form-label" translate>newOffer.payouts</label>
+        <!-- TODO : Use grid -->
         <div class="enum-offer">
           <div class="outcome-group">
             <div class="field-group">
@@ -66,8 +67,9 @@
             </div>
             <div *ngFor="let label of enumEventDescriptor.outcomes" class="field-group enum-payout-group">
               <label class="outcome-label text-right">{{ label }}</label>
-              <input type="number" placeholder="{{ 'unit.satoshis' | translate }}" 
+              <input class="payout-input" type="number" placeholder="{{ 'unit.satoshis' | translate }}" 
                 [value]="outcomeValues[label]" (change)="updateOutcomeValue(label, $event)" min="0">
+              <span class="unit" translate>unit.sats</span>
             </div>
           </div>
         </div>
@@ -75,6 +77,7 @@
   
       <ng-container *ngIf="isNumeric()">
         <label class="mat-form-label" translate>newOffer.payoutCurve</label>
+        <!-- TODO : Use grid -->
         <div class="numeric-offer">
           <div class="outcome-group">
             <div class="numeric-payout-group">
@@ -82,6 +85,10 @@
               <label class="payout-heading text-center" translate>newOffer.payout</label>
               <label class="endpoint-heading text-center" translate>newOffer.endpoint</label>
               <app-more-info matSuffix tooltip="newOfferDescription.outcomes"></app-more-info>
+            </div>
+            <div class="numeric-payout-group">
+              <label class="outcome-heading text-center">{{ units }}</label>
+              <label class="payout-heading text-center" translate>unit.satoshis</label>
             </div>
             <div *ngFor="let point of points; let i = index" class="field-group numeric-payout-group">
               <!-- min will eventually be allowed negative bound to contract params -->

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.scss
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.scss
@@ -32,19 +32,23 @@
         .outcome-label {
           margin-right: 1rem;
         }
-        .payout-label {
+        .payout-input {
           
+        }
+        .unit {
+          margin-left: 0.25rem;
         }
       }
       .enum-payout-group, .numeric-payout-group {
         display: flex;
         flex-direction: row;
         align-items: center;
-        min-height: 40px; // Matches remove buttons on inner rows for numeric
         width: 100%;
+        margin-bottom: 0.25rem;
       }
       .numeric-payout-group {
         &:first-of-type {
+          min-height: 40px; // Matches remove buttons on inner rows for numeric
           margin-bottom: 0.5rem;
         }
 

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
@@ -104,6 +104,7 @@ export class NewOfferComponent implements OnInit {
 
   maturityDate: string
   minDate: Date
+  units: string
 
   theirCollateral: number|'' = ''
 
@@ -148,7 +149,7 @@ export class NewOfferComponent implements OnInit {
   buildChart() {
     if (this.isNumeric()) {
       this.chartData = this.chartService.getChartData()
-      this.chartOptions = this.chartService.getChartOptions(this.numericEventDescriptor.unit)
+      this.chartOptions = this.chartService.getChartOptions(this.units)
       this.updateChartData()
     }
   }
@@ -171,6 +172,11 @@ export class NewOfferComponent implements OnInit {
   private reset() {
     this.maturityDate = formatDateTime(dateToSecondsSinceEpoch(new Date(this.event.maturity)))
     this.minDate = new Date(this.event.maturity)
+    if (this.isNumeric()) {
+      this.units = this.numericEventDescriptor.unit
+    } else {
+      this.units = ''
+    }
     this.outcomeValues = {}
     this.points = []
 


### PR DESCRIPTION
This adds unit labels to spots without on all DLC views and on Contract Detail outcome value.
![Screen Shot 2022-02-02 at 5 50 49 PM](https://user-images.githubusercontent.com/22351459/152263823-99710d0b-c07c-401f-a14a-b99dc1ef7f30.png)
![Screen Shot 2022-02-02 at 5 51 03 PM](https://user-images.githubusercontent.com/22351459/152263830-fb19d649-12a0-49b2-87e6-2ba0fd10ba12.png)
![Screen Shot 2022-02-02 at 5 51 12 PM](https://user-images.githubusercontent.com/22351459/152263844-9971df8c-2b60-4a27-aef7-c38797927b27.png)
![Screen Shot 2022-02-02 at 5 51 25 PM](https://user-images.githubusercontent.com/22351459/152263860-1f01d0a0-13b1-41ff-9140-2b639d254404.png)
![Screen Shot 2022-02-02 at 6 02 29 PM](https://user-images.githubusercontent.com/22351459/152263867-925875fd-81cc-41d7-a008-c13bf66c6cfe.png)
![Screen Shot 2022-02-02 at 6 02 38 PM](https://user-images.githubusercontent.com/22351459/152263876-aa9e9b91-7f53-4df2-82ac-c640c06a7b73.png)

