### PR TITLE
Support ranged outcome values

### DIFF
--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
@@ -105,7 +105,7 @@ export class ContractDetailComponent implements OnInit {
           // Exact outcome case
           if (outcomes.length === numDigits) {
             const numericOutcome = outcomeDigitsToNumber(outcomes)
-            outcome = numericOutcome.toString()
+            outcome = formatNumber(numericOutcome).toString()
             this.outcomePoint = { x: numericOutcome, y: this.dlc.myPayout }
           } else { // Range case
             const range = outcomeDigitsToRange(outcomes, numDigits)

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.ts
@@ -110,7 +110,7 @@ export class ContractDetailComponent implements OnInit {
           } else { // Range case
             const range = outcomeDigitsToRange(outcomes, numDigits)
             if (range) {
-              outcome = range.low + ' - ' + range.high
+              outcome = formatNumber(range.low) + ' - ' + formatNumber(range.high)
               // Place point at midpoint of range and label with full range
               const x = (range.high - range.low) / 2 + range.low
               this.outcomePoint = { x: x, y: this.dlc.myPayout, range: outcome }

--- a/wallet-server-ui/src/service/chart.service.ts
+++ b/wallet-server-ui/src/service/chart.service.ts
@@ -87,12 +87,14 @@ export class ChartService {
           callbacks: {
             label: (context) => {
               // console.debug('label context:', context)
-              let label = ' ' + this.outcomeLabel + ' : ' + context.label + ' ' + units
+              // Handle potential 'range' in outcome values
+              const outcomeValue = (<any>context.raw).range ? (<any>context.raw).range : context.label
+              const label = ' ' + this.outcomeLabel + ' : ' + outcomeValue + ' ' + units
               return label
             },
             afterLabel: (context) => {
               // console.debug('afterLabel context:', context)
-              let text = ' ' + this.payoutLabel + ' : ' + formatNumber((<any>context).raw.y) + ' ' + this.satoshisLabel
+              const text = ' ' + this.payoutLabel + ' : ' + formatNumber((<any>context).raw.y) + ' ' + this.satoshisLabel
               return text
             }
           }

--- a/wallet-server-ui/src/util/utils.ts
+++ b/wallet-server-ui/src/util/utils.ts
@@ -152,3 +152,26 @@ export function outcomeDigitsToNumber(digits: number[]) {
   }
   return sum
 }
+
+function startPadArray(arr: any[], length: number, padding: any) {
+  return Array(length - arr.length).fill(padding).concat(arr)
+}
+
+function endPadArray(arr: any[], length: number, padding: any) {
+  return arr.concat(Array(length - arr.length).fill(padding))
+}
+
+export interface OutcomeRange {
+  high: number,
+  low: number,
+}
+
+// Pad outcomes with 0s or 1s to find range
+export function outcomeDigitsToRange(digits: number[], numDigits: number): OutcomeRange|null {
+  if (digits.length < numDigits) {
+    const high = endPadArray(digits, numDigits, 1)
+    const low = endPadArray(digits, numDigits, 0)
+    return { high: outcomeDigitsToNumber(high), low: outcomeDigitsToNumber(low) }
+  }
+  return null
+}


### PR DESCRIPTION
This supports ranges of outcome values on numeric contracts.
![Screen Shot 2022-02-04 at 10 44 26 AM](https://user-images.githubusercontent.com/22351459/152577298-5a6b03a7-11a0-4088-a7c9-7e652ad7ad9b.png)

Non-ranged:
![Screen Shot 2022-02-04 at 10 46 11 AM](https://user-images.githubusercontent.com/22351459/152577539-87446fbb-51ac-4382-95f1-3afdad812088.png)


I left the graph implementation as a point vs shading range which would take substantially more coding.