### PR TITLE
Add top level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ This project is a set of libraries and front end web UIs for [bitcoin-s](https:/
 
 ### Running the bitcoin-s web frontend
 
-Plese see [wallet-server-ui/README.md]
+Plese see [wallet-server-ui/README.md](wallet-server-ui/README.md)
 
 ### Running the Krystal Bull web front end
 
-Please see [oracle-server-ui/README.md]
+Please see [oracle-server-ui/README.md](oracle-server-ui/README.md)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+This project is a set of libraries and front end web UIs for [bitcoin-s](https://github.com/bitcoin-s/bitcoin-s/)
+
+### Running the bitcoin-s web frontend
+
+Plese see [wallet-server-ui/README.md]
+
+### Running the Krystal Bull web front end
+
+Please see [oracle-server-ui/README.md]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-This project is a set of libraries and front end web UIs for [bitcoin-s](https://github.com/bitcoin-s/bitcoin-s/)
+This project is a set of libraries and frontend web UIs for [bitcoin-s](https://github.com/bitcoin-s/bitcoin-s/)
 
 ### Running the bitcoin-s web frontend
 
 Plese see [wallet-server-ui/README.md](wallet-server-ui/README.md)
 
-### Running the Krystal Bull web front end
+### Running the Krystal Bull web frontend
 
 Please see [oracle-server-ui/README.md](oracle-server-ui/README.md)


### PR DESCRIPTION
From a user

We do have README, just not at the top level. This PR adds a simple README at top level that directs to project specific README

![Screenshot from 2022-02-10 06-10-53](https://user-images.githubusercontent.com/3514957/153406233-ef04b2c2-7de7-4300-b3e2-d56511797b5a.png)

