### PR TITLE
Implement publishing of the wallet-ts project

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,7 @@ name: npm-publish
 on:
   push:
     branches:
-      [master, main, 2021-10-11-npm-publish-bug] # Change this to your default branch
+      [master, main] # Change this to your default branch
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,8 @@ jobs:
       - run: |
           cd oracle-server-ts
           npm install
+          cd ../wallet-ts
+          npm install
       - name: Set outputs
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short=8 HEAD)"
@@ -24,5 +26,11 @@ jobs:
         with:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
           package: ./oracle-server-ts/package.json
+          #tag: "${{steps.vars.outputs.sha_short}}"
+          check-version: true # will not publish unless version is changed
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_AUTH_TOKEN }}
+          package: ./wallet-ts/package.json
           #tag: "${{steps.vars.outputs.sha_short}}"
           check-version: true # will not publish unless version is changed


### PR DESCRIPTION
fixes #88 

This should publish a `0.0.4` version of `wallet-ts` as there was never a version published. The way the workflows work is it checks `npmjs.com` if the version exists, it does not publish. If it does not exist, it publishes to `npmjs.com`

https://github.com/JS-DevTools/npm-publish