### PR TITLE
Remove private field on package.json so we can publish

### DIFF
--- a/wallet-ts/package.json
+++ b/wallet-ts/package.json
@@ -10,7 +10,6 @@
     "build": "tsc",
     "tests": "npx ts-node tests.ts"
   },
-  "private": true,
   "dependencies": {
     "common-ts": "file:../common-ts",
     "needle": "^3.0.0"


### PR DESCRIPTION
There was a bug in #93 

This PR unmarks the wallet-ts package as private

https://github.com/bitcoin-s/bitcoin-s-ts/runs/5189810106?check_suite_focus=true#step:8:73

![Screenshot from 2022-02-14 13-56-42](https://user-images.githubusercontent.com/3514957/153936895-545c172d-8fcb-46d8-8e7f-c55b8ee9cfec.png)
