### PR TITLE
Add bitcoin-s organization to wallet-ts library

### DIFF
--- a/wallet-ts/package.json
+++ b/wallet-ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wallet-ts",
+  "name": "@bitcoin-s-ts/wallet-ts",
   "version": "0.0.1",
   "description": "NodeJS package for accessing bitcoin-s wallet",
   "main": "dist/index.js",


### PR DESCRIPTION
We need to add the organization qualifier to wallet-ts like we did for the oracle ts project here: 

https://github.com/bitcoin-s/bitcoin-s-ts/commit/818d64fc6b0601cd7a6fb4f07bc690603f3a2db8#diff-506e347f3b818889392e504234b3cec3272ea6e851f477c52ed472fcea5bf90aR2