### PR TITLE
Try to change access explicitly to public

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,11 +26,13 @@ jobs:
         with:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
           package: ./oracle-server-ts/package.json
+          access: "public"
           #tag: "${{steps.vars.outputs.sha_short}}"
           check-version: true # will not publish unless version is changed
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
           package: ./wallet-ts/package.json
+          access: "public"
           #tag: "${{steps.vars.outputs.sha_short}}"
           check-version: true # will not publish unless version is changed


### PR DESCRIPTION
Stll getting these. This PR tries to set the package `access` as public. This is a configuration setting from the workflow:

https://github.com/JS-DevTools/npm-publish

https://github.com/bitcoin-s/bitcoin-s-ts/runs/5190962300?check_suite_focus=true#step:8:72

![Screenshot from 2022-02-14 15-38-27](https://user-images.githubusercontent.com/3514957/153950808-cf74a635-52ec-430a-82be-2b15c77de258.png)
