### PR TITLE
Removes the 'v' prefix for detecting a tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,6 +32,19 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Build and push oracle server ui tag
+        if: startsWith(github.ref, 'refs/tags/')
+        env: 
+          pkg-version: ${{steps.previoustag.outputs.tag}}
+        run: |
+          docker buildx create --use --name multi-arch-builder
+          docker buildx build --platform=linux/amd64,linux/arm64 --push -f oracle-server-ui/Dockerfile -t bitcoinscala/oracle-server-ui:latest -t bitcoinscala/oracle-server-ui:${{steps.previoustag.outputs.tag}} .
+      - name: Build and push wallet server ui tag
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          pkg-version: ${{steps.previoustag.outputs.tag}}
+        run: |
+          docker buildx build --platform=linux/amd64,linux/arm64 --push -f wallet-server-ui/Dockerfile -t bitcoinscala/wallet-server-ui:latest -t bitcoinscala/wallet-server-ui:${{steps.previoustag.outputs.tag}} .
       - name: Build and push oracle server ui SNAPSHOT
         env: 
           pkg-version: ${{steps.previoustag.outputs.tag}}
@@ -43,17 +56,4 @@ jobs:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         run: |
           docker buildx build --platform=linux/amd64,linux/arm64 --push -f wallet-server-ui/Dockerfile -t bitcoinscala/wallet-server-ui:latest -t bitcoinscala/wallet-server-ui:${{steps.previoustag.outputs.tag}}-${{ steps.vars.outputs.sha_short }}-SNAPSHOT .
-      - name: Build and push oracle server ui tag
-        if: startsWith(github.ref, 'refs/tags/v')
-        env: 
-          pkg-version: ${{steps.previoustag.outputs.tag}}
-        run: |
-          docker buildx create --use --name multi-arch-builder
-          docker buildx build --platform=linux/amd64,linux/arm64 --push -f oracle-server-ui/Dockerfile -t bitcoinscala/oracle-server-ui:latest -t bitcoinscala/oracle-server-ui:${{steps.previoustag.outputs.tag}} .
-      - name: Build and push wallet server ui tag
-        if: startsWith(github.ref, 'refs/tags/v')
-        env:
-          pkg-version: ${{steps.previoustag.outputs.tag}}
-        run: |
-          docker buildx build --platform=linux/amd64,linux/arm64 --push -f wallet-server-ui/Dockerfile -t bitcoinscala/wallet-server-ui:latest -t bitcoinscala/wallet-server-ui:${{steps.previoustag.outputs.tag}} .
       


### PR DESCRIPTION
This PR does

1. Removes the leading `v` prefix for detecting if we have a tag. We don't prefix our tags with `v`
2. Publishes the releases first rather than the SNAPSHOTs. This is moved to make it easier for me to test.