### PR TITLE
Add external address support

### DIFF
--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
@@ -119,6 +119,36 @@
           <span matSuffix translate>unit.satsPerVbyte</span>
         </mat-form-field>
       </div>
+
+      <!-- Advanced -->
+      <mat-expansion-panel *ngIf="advancedVisible">
+        <mat-expansion-panel-header>
+          <mat-panel-title translate>newOffer.advanced</mat-panel-title>
+        </mat-expansion-panel-header>
+        <zxing-scanner *ngIf="qrScanEnabled"
+          [enable]="qrScanEnabled"
+          (camerasFound)="camerasFoundHandler($event)"
+          (camerasNotFound)="camerasNotFoundHandler($event)"
+          (scanError)="scanErrorHandler($event)"
+          (scanComplete)="scanCompleteHandler($event)"
+        ></zxing-scanner>
+        <mat-form-field class="w-100">
+          <mat-label translate>newOffer.externalPayoutAddress</mat-label>
+          <input formControlName="externalPayoutAddress" matInput type="text" spellcheck="false">
+          <span matSuffix class="validation">
+            <mat-icon *ngIf="externalPayoutAddress?.valid && !externalPayoutAddress?.pristine" class="material-icons-outlined"
+              matTooltip="{{ 'dialog.sendFunds.addressValid' | translate }}">check_circle</mat-icon>
+            <mat-icon *ngIf="externalPayoutAddress?.invalid && (externalPayoutAddress?.dirty || externalPayoutAddress?.touched)" class="material-icons-outlined"
+              matTooltip="{{ 'dialog.sendFunds.addressInvalid' | translate }}">cancel</mat-icon>
+          </span>
+          <button *ngIf="!qrScanNoCamera" class="mat-stroked-icon-button-sm" mat-stroked-button matSuffix
+            matTooltip="{{ 'dialog.sendFunds.scanQRCode' | translate }}"
+            (click)="scanQRCode()">
+            <mat-icon>qr_code_scanner</mat-icon>
+          </button>
+          <app-more-info matSuffix tooltip="newOfferDescription.externalPayoutAddress"></app-more-info>
+        </mat-form-field>
+      </mat-expansion-panel>
       
     </fieldset>
 

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.scss
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.scss
@@ -83,6 +83,10 @@
     }
   }
 
+  .mat-stroked-icon-button-sm {
+    margin-left: 0.5rem;
+  }
+
   .form-container {
     .accept-offer-type {
       mat-radio-button {

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
@@ -179,6 +179,35 @@
         </mat-form-field>
       </div>
 
+      <!-- Advanced -->
+      <mat-expansion-panel *ngIf="advancedVisible">
+        <mat-expansion-panel-header>
+          <mat-panel-title translate>newOffer.advanced</mat-panel-title>
+        </mat-expansion-panel-header>
+        <zxing-scanner *ngIf="qrScanEnabled"
+          [enable]="qrScanEnabled"
+          (camerasFound)="camerasFoundHandler($event)"
+          (camerasNotFound)="camerasNotFoundHandler($event)"
+          (scanError)="scanErrorHandler($event)"
+          (scanComplete)="scanCompleteHandler($event)"
+        ></zxing-scanner>
+        <mat-form-field class="w-100">
+          <mat-label translate>newOffer.externalPayoutAddress</mat-label>
+          <input formControlName="externalPayoutAddress" matInput type="text" spellcheck="false">
+          <span matSuffix class="validation">
+            <mat-icon *ngIf="externalPayoutAddress?.valid && !externalPayoutAddress?.pristine" class="material-icons-outlined"
+              matTooltip="{{ 'dialog.sendFunds.addressValid' | translate }}">check_circle</mat-icon>
+            <mat-icon *ngIf="externalPayoutAddress?.invalid && (externalPayoutAddress?.dirty || externalPayoutAddress?.touched)" class="material-icons-outlined"
+              matTooltip="{{ 'dialog.sendFunds.addressInvalid' | translate }}">cancel</mat-icon>
+          </span>
+          <button *ngIf="!qrScanNoCamera" class="mat-stroked-icon-button-sm" mat-stroked-button matSuffix
+            matTooltip="{{ 'dialog.sendFunds.scanQRCode' | translate }}"
+            (click)="scanQRCode()">
+            <mat-icon>qr_code_scanner</mat-icon>
+          </button>
+          <app-more-info matSuffix tooltip="newOfferDescription.externalPayoutAddress"></app-more-info>
+        </mat-form-field>
+      </mat-expansion-panel>
     </fieldset>
   </form>
 

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.scss
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.scss
@@ -112,6 +112,14 @@
     }
   }
 
+  .validation {
+    vertical-align: sub;
+  }
+
+  .mat-stroked-icon-button-sm {
+    margin-left: 0.5rem;
+  }
+
   .description {
     margin: 1rem 0 1rem 0;
     line-height: 1.3;

--- a/wallet-server-ui/src/app/dialog/send-funds-dialog/send-funds-dialog.component.html
+++ b/wallet-server-ui/src/app/dialog/send-funds-dialog/send-funds-dialog.component.html
@@ -19,7 +19,7 @@
           <mat-icon *ngIf="address?.invalid && (address?.dirty || address?.touched)" class="material-icons-outlined"
             matTooltip="{{ 'dialog.sendFunds.addressInvalid' | translate }}">cancel</mat-icon>
         </span>
-        <button *ngIf="!qrScanNoCamera" mat-icon-button matSuffix
+        <button *ngIf="!qrScanNoCamera" class="mat-stroked-icon-button-sm" mat-stroked-button matSuffix
           matTooltip="{{ 'dialog.sendFunds.scanQRCode' | translate }}"
           (click)="scanQRCode()">
           <mat-icon>qr_code_scanner</mat-icon>

--- a/wallet-server-ui/src/app/dialog/send-funds-dialog/send-funds-dialog.component.scss
+++ b/wallet-server-ui/src/app/dialog/send-funds-dialog/send-funds-dialog.component.scss
@@ -8,9 +8,12 @@
   fieldset {
     display: flex;
     flex-direction: column;
-    
+
     .validation {
       vertical-align: sub;
+    }
+    button[matSuffix] {
+      margin-left: 0.5rem;
     }
     span, mat-button-toggle {
       margin-left: 0.5rem;

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -165,6 +165,8 @@
     "totalCollateral": "Total",
     "feeRate": "Fee Rate",
     "refundDate": "Refund Date",
+    "advanced": "Advanced",
+    "externalPayoutAddress": "External Payout Address",
     "createOffer": "Create Offer",
     "offerCreated": "Offer Created"
   },
@@ -176,7 +178,8 @@
     "feeRate": "Fee Rate built into contract (sats/vbyte)",
     "refundDate": "When the contract can be refunded",
     "createOffer": "Create this DLC Offer in your wallet and reserve funds.",
-    "createOffer2": "You will send the hex string representing your offer in Result below to your counterparty along with your Tor DLC Host Address to complete the contract."
+    "createOffer2": "You will send the hex string representing your offer in Result below to your counterparty along with your Tor DLC Host Address to complete the contract.",
+    "externalPayoutAddress": "Use Payout Address outside of the Suredbits Wallet"
   },
 
   "newOfferValidation": {

--- a/wallet-server-ui/src/service/auth.service.ts
+++ b/wallet-server-ui/src/service/auth.service.ts
@@ -17,7 +17,7 @@ const EXPIRES_KEY = 'expires_at'
 interface LoginResponse { accessToken: string, refreshToken: string, expiresIn: number }
 
 const LOGOUT_DELAY = 60000 // ms
-const LOGOUT_FUDGE_FACTOR = 45000 // ms, extra padding on logout to make sure async actions don't trigger 400 errors close to logout
+const LOGOUT_FUDGE_FACTOR = 60000 // ms, extra padding on logout to make sure async actions don't trigger 400 errors close to logout
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {

--- a/wallet-server-ui/src/service/wallet-state-service.ts
+++ b/wallet-server-ui/src/service/wallet-state-service.ts
@@ -248,7 +248,7 @@ export class WalletStateService {
     }))
   }
 
-  private refreshUnfundedAddresses() {
+  refreshUnfundedAddresses() {
     return this.messageService.sendMessage(getMessageBody(WalletMessageType.getunusedaddresses)).pipe(tap(r => {
       if (r.result) {
         this.unfundedAddresses = r.result

--- a/wallet-server-ui/src/service/websocket.service.ts
+++ b/wallet-server-ui/src/service/websocket.service.ts
@@ -128,7 +128,6 @@ export class WebsocketService {
   private handleMessage(message: WebsocketMessage) {
     console.debug('handleMessage() type:', message.type)
     switch (message.type) {
-      case WebsocketMessageType.newaddress:
       case WebsocketMessageType.txbroadcast:
       case WebsocketMessageType.txprocessed:
         // Nothing to do
@@ -154,6 +153,9 @@ export class WebsocketService {
         break;
       case WebsocketMessageType.reservedutxos:
         this.walletStateService.refreshBalances().subscribe()
+        break;
+      case WebsocketMessageType.newaddress:
+        this.walletStateService.refreshUnfundedAddresses().subscribe()
         break;
       default:
         console.error('handleMessage() unknown message.type', message)

--- a/wallet-server-ui/src/styles.scss
+++ b/wallet-server-ui/src/styles.scss
@@ -116,6 +116,13 @@ fieldset {
 
 /** Material Design */
 
+// Suppress side drawer horizontal scroll
+mat-sidenav {
+  .mat-drawer-inner-container {
+    overflow-x: hidden;
+  }
+}
+
 /** Buttons */
 
 .mat-flat-button.mat-flat-button-sm,
@@ -206,12 +213,18 @@ mat-form-field {
   }
 }
 
+
 .mat-form-field-suffix {
   .mat-flat-button-sm {
     vertical-align: super;
   }
   .mat-button-toggle-sm {
     vertical-align: super;
+  }
+  .mat-stroked-button.mat-stroked-icon-button-sm {
+    min-width: unset;
+    vertical-align: super;
+    padding: 0 8px;
   }
 }
 

--- a/wallet-server-ui/src/util/utils.ts
+++ b/wallet-server-ui/src/util/utils.ts
@@ -97,9 +97,20 @@ export function datePlusDays(date: Date, days: number) {
   return date
 }
 
-export function formatNumber(n: number): string {
+export function formatNumber(n: number | undefined | null): string {
   if (n === undefined || n === null) return ''
   return n.toLocaleString()
+}
+
+export function formatNumberString(s: string | undefined | null): string {
+  if (s === undefined || s === null) return ''
+  try {
+    const n = parseFloat(s)
+    return n.toLocaleString()
+  } catch (err) {
+    // Ignore error
+  }
+  return ''
 }
 
 export function formatPercent(num: number, fractionalDigits = 2, addPercentSign = true): string {

--- a/wallet-server-ui/src/util/validators.ts
+++ b/wallet-server-ui/src/util/validators.ts
@@ -29,6 +29,19 @@ export function bitcoinAddressValidator(network: string | undefined): ValidatorF
   }
 }
 
+export function allowEmptybitcoinAddressValidator(network: string | undefined): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    if (control.value === '') {
+      console.debug('allowEmptybitcoinAddressValidator() control.value:', control.value)
+      // control.markAsUntouched()
+      control.markAsPristine()
+      return null
+    }
+    const allowed = validate(control.value, <Network>network)
+    return allowed ? null : { addressInvalid: { value: control.value } }
+  }
+}
+
 
 // Get network name to use with bitcoin-address-validation
 // export function getValidationNetworkName(network: BitcoinNetwork) {


### PR DESCRIPTION
Adds 'Advanced' expansion panels for selecting an External Payout Address on the Offer and Accept views. Allows using QR Code scanning to populate addresses. Refreshes Unfunded Address list when `newaddress` message is received. Updates QR Code button on Send Funds.

![Screen Shot 2022-02-22 at 5 59 51 PM](https://user-images.githubusercontent.com/22351459/155245762-f04c3c30-4ed6-4911-ad91-76e7e230094f.png)
![Screen Shot 2022-02-22 at 6 00 24 PM](https://user-images.githubusercontent.com/22351459/155245778-c784b4df-734b-4f95-8ccb-b57af8f28f2b.png)
![Screen Shot 2022-02-22 at 6 03 21 PM](https://user-images.githubusercontent.com/22351459/155245782-34265ddd-a7a5-4a38-b2a3-adcedf3aca64.png)