### PR TITLE
Implement offer-send UI

### DIFF
--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.html
@@ -178,7 +178,8 @@
 
       <mat-form-field *ngIf="acceptOfferType === AcceptOfferType.TOR" class="w-100">
         <mat-label translate>acceptOffer.peerAddress</mat-label>
-        <input matInput formControlName="peerAddress" type="text" spellcheck="false"
+        <input matInput formControlName="peerAddress" type="text"
+          autocomplete="off" spellcheck="false" maxlength="1024"
           placeholder="{{ 'acceptOffer.peerAddressPlaceholder' | translate }}"
           (paste)="peerAddressValue = trimOnPaste($event)">
         <app-more-info matSuffix tooltip="acceptOfferDescription.peerAddress"></app-more-info>

--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.scss
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.scss
@@ -104,7 +104,7 @@
   .form-container {
     .accept-offer-type {
       mat-radio-button {
-        margin-right: 0.5rem;
+        margin-right: 1rem;
       }
     }
     .description {

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -259,7 +259,7 @@
     <div class="description text-justify" translate>newOfferDescription.offerType.tor</div>
 
     <form class="form-container" [formGroup]="offerForm" autocomplete="off">
-      <fieldset>
+      <fieldset [disabled]="executing || offerSent">
         <mat-form-field class="w-100">
           <mat-label translate>newOffer.message</mat-label>
           <textarea matInput formControlName="message" type="text"

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -254,6 +254,48 @@
     </button>
   </div>
 
+  <div *ngIf="dlc.state === DLCState.offered">
+    <h2 translate>contractDetail.sendToCounterparty</h2>
+    <div class="description text-justify" translate>newOfferDescription.offerType.tor</div>
+
+    <form class="form-container" [formGroup]="offerForm" autocomplete="off">
+      <fieldset>
+        <mat-form-field class="w-100">
+          <mat-label translate>newOffer.message</mat-label>
+          <textarea matInput formControlName="message" type="text"
+            cdkTextareaAutosize cdkAutosizeMinRows="2"
+            autocomplete="off" spellcheck="false" maxlength="1024"
+            (paste)="onMessagePaste($event)"></textarea>
+          <app-more-info matSuffix tooltip="newOfferDescription.message"></app-more-info>
+        </mat-form-field>
+        <mat-form-field class="w-100">
+          <mat-label translate>acceptOffer.peerAddress</mat-label>
+          <input matInput formControlName="peerAddress" type="text"
+            autocomplete="off" spellcheck="false" maxlength="1024"
+            placeholder="{{ 'acceptOffer.peerAddressPlaceholder' | translate }}"
+            (paste)="peerAddressValue = trimOnPaste($event)">
+          <app-more-info matSuffix tooltip="newOfferDescription.peerAddress"></app-more-info>
+        </mat-form-field>
+      </fieldset>
+    </form>
+
+    <div class="execute-container">
+      <div class="button-group">
+        <button mat-flat-button color="primary" (click)="onSendOffer()"
+          [disabled]="offerForm.invalid || executing || offerSent">
+          <mat-icon class="material-icons-outlined">cloud_sync</mat-icon>
+          <span translate>action.execute</span>
+        </button>
+        <div *ngIf="executing" class="spinner">
+          <mat-spinner diameter="20"></mat-spinner>
+        </div>
+      </div>
+    </div>
+
+    <app-alert *ngIf="offerSent" [type]="AlertType.success" icon="check_circle"
+      message="newOffer.offerSent"></app-alert>
+  </div>
+
   <!-- Signing Accept -->
   <div *ngIf="accept" class="accept-group">
     <h2 translate>contractDetail.signAcceptOffer</h2>

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
@@ -216,18 +216,50 @@
 
   <h2 translate>newOffer.createOffer</h2>
   <div class="description text-justify" translate>newOfferDescription.createOffer</div>
-  <div class="description text-justify" translate>newOfferDescription.createOffer2</div>
+
+  <form [formGroup]="typeForm" class="form-container">
+    <fieldset [disabled]="executing || offerCreated">
+      <mat-radio-group class="offer-type"
+        [value]="offerType" (change)="updateOfferType($event)">
+        <mat-radio-button *ngFor="let e of offerTypes"
+          [value]="e">{{ 'newOffer.offerType.' + e | translate }}</mat-radio-button>
+      </mat-radio-group>
+  
+      <div class="description">
+        {{ 'newOfferDescription.offerType.' + offerType | translate }}
+      </div>
+
+      <ng-container *ngIf="offerType === OfferType.TOR">
+        <mat-form-field class="w-100">
+          <mat-label translate>newOffer.message</mat-label>
+          <textarea matInput formControlName="message" type="text"
+            cdkTextareaAutosize cdkAutosizeMinRows="2"
+            autocomplete="off" spellcheck="false" maxlength="1024"
+            (paste)="messageValue = trimOnPaste($event)"></textarea>
+          <app-more-info matSuffix tooltip="newOfferDescription.message"></app-more-info>
+        </mat-form-field>
+        <mat-form-field class="w-100">
+          <mat-label translate>acceptOffer.peerAddress</mat-label>
+          <input matInput formControlName="peerAddress" type="text"
+            autocomplete="off" spellcheck="false" maxlength="1024"
+            placeholder="{{ 'acceptOffer.peerAddressPlaceholder' | translate }}"
+            (paste)="peerAddressValue = trimOnPaste($event)">
+          <app-more-info matSuffix tooltip="newOfferDescription.peerAddress"></app-more-info>
+        </mat-form-field>
+      </ng-container>
+    </fieldset>
+  </form>
 
   <div class="execute-container">
     <div class="button-group">
-      <button mat-stroked-button class="tor-dlc-host-address-button"
+      <button [hidden]="offerType === OfferType.TOR" mat-stroked-button class="tor-dlc-host-address-button"
         matTooltip="{{ 'action.copyToClipboard' | translate }}"
         (click)="copyToClipboard(walletStateService.torDLCHostAddress)">
         <mat-icon>content_copy</mat-icon>
         <span translate>torDLCHostAddress</span>
       </button>
       <button mat-flat-button color="primary" (click)="onExecute()"
-        [disabled]="form.invalid || payoutInputsInvalid || offerCreated">
+        [disabled]="form.invalid || typeForm.invalid || payoutInputsInvalid || offerCreated">
         {{ 'action.execute' | translate }}
       </button>
       <div class="spinner" [hidden]="!executing">
@@ -242,7 +274,7 @@
   
   <!-- Could have button to open new contract or auto-open new contract detail -->
 
-  <div class="result-footer">
+  <div class="result-footer" [hidden]="offerType === OfferType.TOR">
     <!-- <div class="button-group">
       <button mat-stroked-button matTooltip="{{ 'action.copyToClipboard' | translate }}">
         <mat-icon>content_copy</mat-icon>

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
@@ -235,7 +235,7 @@
           <textarea matInput formControlName="message" type="text"
             cdkTextareaAutosize cdkAutosizeMinRows="2"
             autocomplete="off" spellcheck="false" maxlength="1024"
-            (paste)="messageValue = trimOnPaste($event)"></textarea>
+            (paste)="onMessagePaste($event)"></textarea>
           <app-more-info matSuffix tooltip="newOfferDescription.message"></app-more-info>
         </mat-form-field>
         <mat-form-field class="w-100">

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
@@ -260,7 +260,9 @@
       </button>
       <button mat-flat-button color="primary" (click)="onExecute()"
         [disabled]="form.invalid || typeForm.invalid || payoutInputsInvalid || offerCreated">
-        {{ 'action.execute' | translate }}
+        <mat-icon *ngIf="offerType === OfferType.TOR" class="material-icons-outlined">cloud_sync</mat-icon>
+        <mat-icon *ngIf="offerType === OfferType.TEXT" class="material-icons-outlined">text_snippet</mat-icon>
+        <span translate>action.execute</span>
       </button>
       <div class="spinner" [hidden]="!executing">
         <mat-spinner diameter="20"></mat-spinner>
@@ -268,9 +270,8 @@
     </div>
   </div>
 
-  <ng-container *ngIf="offerCreated">
-    <app-alert [type]="AlertType.success" message="newOffer.offerCreated" icon="check_circle"></app-alert>
-  </ng-container>
+  <app-alert *ngIf="offerCreated" [type]="AlertType.success" message="newOffer.offerCreated" icon="check_circle"></app-alert>
+  <app-alert *ngIf="offerSent" [type]="AlertType.success" message="newOffer.offerSent" icon="check_circle"></app-alert>
   
   <!-- Could have button to open new contract or auto-open new contract detail -->
 

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.scss
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.scss
@@ -1,6 +1,7 @@
 
 .new-offer {
   max-width: 450px;
+  padding-bottom: 0.5rem;
 
   .enum-offer, .numeric-offer {
     .field-group {

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.scss
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.scss
@@ -110,6 +110,15 @@
         margin-left: 0.25rem;
       }
     }
+    .offer-type {
+      mat-radio-button {
+        margin-right: 1rem;
+      }
+    }
+    .description {
+      margin: 1rem 0 1rem 0;
+      line-height: 1.3;
+    }
   }
 
   .validation {

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
@@ -115,6 +115,7 @@ export class NewOfferComponent implements OnInit {
 
   typeForm: FormGroup
   get tf() { return this.typeForm.controls }
+  get messageValue() { return this.typeForm.get('message')?.value }
   set messageValue(message: string) { this.typeForm.patchValue({ message }) }
   set peerAddressValue(peerAddress: string) { this.typeForm.patchValue({ peerAddress }) }
 
@@ -608,4 +609,9 @@ export class NewOfferComponent implements OnInit {
     }
   }
 
+  onMessagePaste(event: ClipboardEvent) {
+    // Only trimOnPaste() if there is no value in the field already
+    if (!this.messageValue) this.messageValue = trimOnPaste(event)
+  }
+  
 }

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
@@ -394,7 +394,7 @@ export class NewOfferComponent implements OnInit {
 
         if (this.offerType === OfferType.TOR) {
           const v = this.typeForm.value
-          this.offerService.sendIncomingOffer(this.newOfferResult, v.peer, v.message).subscribe(r => {
+          this.offerService.sendIncomingOffer(this.newOfferResult, v.peerAddress, v.message).subscribe(r => {
             console.warn(' sendIncomingOffer', r)
             if (r.result) {
 

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
@@ -5,6 +5,8 @@ import { MatRadioChange } from '@angular/material/radio'
 import { ChartData, ChartOptions } from 'chart.js'
 import { TranslateService } from '@ngx-translate/core'
 import { BaseChartDirective } from 'ng2-charts'
+import { of } from 'rxjs'
+import { catchError } from 'rxjs/operators'
 import { Result } from '@zxing/library'
 
 import { ChartService } from '~service/chart.service'
@@ -396,8 +398,8 @@ export class NewOfferComponent implements OnInit {
 
         if (this.offerType === OfferType.TOR) {
           const v = this.typeForm.value
-          // TODO : This needs to run on offer.temporaryContractId
-          this.offerService.sendIncomingOffer(this.newOfferResult, v.peerAddress, v.message).subscribe(r => {
+          this.offerService.sendIncomingOffer(this.newOfferResult, v.peerAddress, v.message)
+          .pipe(catchError(error => of({ result: null }))).subscribe(r => {
             console.warn(' sendIncomingOffer', r)
             if (r.result) {
               this.offerSent = true

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
@@ -1,6 +1,7 @@
 import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core'
 import { FormBuilder, FormGroup, Validators } from '@angular/forms'
 import { MatDatepickerInput } from '@angular/material/datepicker'
+import { MatRadioChange } from '@angular/material/radio'
 import { ChartData, ChartOptions } from 'chart.js'
 import { TranslateService } from '@ngx-translate/core'
 import { BaseChartDirective } from 'ng2-charts'
@@ -9,19 +10,25 @@ import { Result } from '@zxing/library'
 import { ChartService } from '~service/chart.service'
 import { DarkModeService } from '~service/dark-mode.service'
 import { MessageService } from '~service/message.service'
+import { OfferService } from '~service/offer-service'
 import { WalletStateService } from '~service/wallet-state-service'
 
 import { DLCMessageType, EnumContractDescriptor, EnumEventDescriptor, Event, NumericContractDescriptor, NumericEventDescriptor, PayoutFunctionPoint, WalletMessageType } from '~type/wallet-server-types'
 import { AnnouncementWithHex, ContractInfoWithHex } from '~type/wallet-ui-types'
 
-import { copyToClipboard, datePlusDays, dateToSecondsSinceEpoch, formatDateTime, formatNumber, networkToValidationNetwork, trimOnPaste } from '~util/utils'
-import { allowEmptybitcoinAddressValidator } from '~util/validators'
+import { copyToClipboard, datePlusDays, dateToSecondsSinceEpoch, formatDateTime, formatNumber, networkToValidationNetwork, TOR_V3_ADDRESS, trimOnPaste } from '~util/utils'
+import { allowEmptybitcoinAddressValidator, regexValidator } from '~util/validators'
 import { getMessageBody } from '~util/wallet-server-util'
 
 import { AlertType } from '~component/alert/alert.component'
 
 
 const DEFAULT_DAYS_UNTIL_REFUND = 7
+
+enum OfferType {
+  TOR = 'tor',
+  TEXT = 'text'
+}
 
 @Component({
   selector: 'app-new-offer',
@@ -31,6 +38,7 @@ const DEFAULT_DAYS_UNTIL_REFUND = 7
 export class NewOfferComponent implements OnInit {
 
   public AlertType = AlertType
+  public OfferType = OfferType
   public copyToClipboard = copyToClipboard
   public trimOnPaste = trimOnPaste
 
@@ -105,6 +113,11 @@ export class NewOfferComponent implements OnInit {
   get externalPayoutAddress() { return this.form.get('externalPayoutAddress') }
   set externalPayoutAddressValue(externalPayoutAddress: string) { this.form.patchValue({ externalPayoutAddress }) }
 
+  typeForm: FormGroup
+  get tf() { return this.typeForm.controls }
+  set messageValue(message: string) { this.typeForm.patchValue({ message }) }
+  set peerAddressValue(peerAddress: string) { this.typeForm.patchValue({ peerAddress }) }
+
   @ViewChild('datePicker') datePicker: MatDatepickerInput<Date>
 
   maturityDate: string
@@ -170,6 +183,14 @@ export class NewOfferComponent implements OnInit {
     }
   }
 
+  offerTypes = [OfferType.TOR, OfferType.TEXT]
+  offerType = OfferType.TOR
+  updateOfferType(event: MatRadioChange) {
+    // console.debug('updateAcceptOfferType()', event)
+    this.offerType = event.value
+    this.wipeInvalidFormStates()
+  }
+
   advancedVisible = false // Angular hack
   qrScanNoCamera = false
   qrScanEnabled = false
@@ -227,6 +248,21 @@ export class NewOfferComponent implements OnInit {
         externalPayoutAddress: '',
       })
     }
+    if (this.typeForm) {
+      this.typeForm.patchValue({
+        message: '',
+        peerAddress: '',
+      })
+    }
+  }
+
+  wipeInvalidFormStates() {
+    console.debug('wipeInvalidFormStates()', this.offerType)
+    if (this.offerType === OfferType.TOR) {
+      this.tf['peerAddress'].updateValueAndValidity()
+    } else if (this.offerType === OfferType.TEXT) {
+      this.tf['peerAddress'].setErrors(null)
+    }
   }
 
   getPoint(outcome: number, payout: number, extraPrecision: number, isEndpoint: boolean) {
@@ -238,6 +274,7 @@ export class NewOfferComponent implements OnInit {
   }
 
   constructor(private messageService: MessageService, public walletStateService: WalletStateService,
+    private offerService: OfferService,
     private formBuilder: FormBuilder, private translate: TranslateService,
     private chartService: ChartService, private darkModeService: DarkModeService) { }
 
@@ -254,6 +291,10 @@ export class NewOfferComponent implements OnInit {
       // outcomes?
       externalPayoutAddress: ['',
         allowEmptybitcoinAddressValidator(networkToValidationNetwork(this.walletStateService.getNetwork() || undefined))],
+    })
+    this.typeForm = this.formBuilder.group({
+      message: [''],
+      peerAddress: ['', [Validators.required, regexValidator(TOR_V3_ADDRESS)]],
     })
     if (this.contractInfo) {
       this.onTotalCollateral()
@@ -297,13 +338,13 @@ export class NewOfferComponent implements OnInit {
     // this.contractInfo.hex is no good, need announcement hex from this.contractInfo
     const hex = this.announcement ? this.announcement.hex : this.contractInfo.contractInfo.oracleInfo.announcement.hex
     const v = this.form.value
+    const totalCollateral = v.totalCollateral
 
     this.executing = true
     // TODO : Error handlers to unset executing in failure cases
 
     if (this.isEnum()) {
       const payoutVals = this.buildPayoutVals()
-      const totalCollateral = v.totalCollateral
       // const maxCollateral = this.computeMaxCollateral(payoutVals)
   
       console.debug('payoutVals:', payoutVals, 'totalCollateral:', totalCollateral)
@@ -311,68 +352,58 @@ export class NewOfferComponent implements OnInit {
       this.messageService.sendMessage(getMessageBody(DLCMessageType.createcontractinfo, 
         [hex, totalCollateral, payoutVals])).subscribe(r => {
           console.debug('createcontractinfo', r)
-  
           if (r.result) {
-            const contractInfoTLV = <string>r.result
-            const collateral = v.yourCollateral
-            const feeRate = v.feeRate
-            const locktime = dateToSecondsSinceEpoch(new Date(this.event.maturity))
-            const refundLT = dateToSecondsSinceEpoch(v.refundDate)
-            const payoutAddress = v.externalPayoutAddress ? v.externalPayoutAddress.trim() : null
-            const changeAddress = null
-
-            // console.debug('collateral:', collateral, 'feeRate:', feeRate, 'locktime:', locktime, 'refundLT:', refundLT)
-
-            this.messageService.sendMessage(getMessageBody(WalletMessageType.createdlcoffer, 
-              [contractInfoTLV, collateral, feeRate, locktime, refundLT, payoutAddress, changeAddress])).subscribe(r => {
-              console.warn('CreateDLCOffer()', r)
-              if (r.result) {
-                this.newOfferResult = r.result
-                // this.walletStateService.refreshDLCStates() // via websocket now
-                this.offerCreated = true
-              }
-              this.executing = false
-            })
+            this.handleContractInfo(r.result)
           }
         })
     } else if (this.isNumeric()) {
       const numericPayoutVals = this.points
-      const totalCollateral = v.totalCollateral
       // const maxCollateral = this.computeNumericMaxCollateral(numericPayoutVals)
 
       console.warn('numericPayoutVals:', numericPayoutVals, 'totalCollateral:', totalCollateral, 'yourCollateral:', v.yourCollateral)
       
-      // console.debug('numericAnnouncementHex:', numericAnnouncementHex, 'totalCollateral:', totalCollateral, 'numericPayoutVals:', numericPayoutVals)
       this.messageService.sendMessage(getMessageBody(DLCMessageType.createcontractinfo, 
         [hex, totalCollateral, numericPayoutVals])).subscribe(r => {
         console.warn('createcontractinfo', r)
-
         if (r.result) {
-          const contractInfoTLV = <string>r.result
-          const collateral = v.yourCollateral
-          const feeRate = v.feeRate
-          const locktime = dateToSecondsSinceEpoch(new Date(this.event.maturity))
-          const refundLT = dateToSecondsSinceEpoch(v.refundDate)
-          const payoutAddress = v.externalPayoutAddress ? v.externalPayoutAddress.trim() : null
-          const changeAddress = null
-
-          console.debug('collateral:', collateral, 'feeRate:', feeRate, 'locktime:', locktime, 'refundLT:', refundLT)
-
-          this.messageService.sendMessage(getMessageBody(WalletMessageType.createdlcoffer, 
-            [contractInfoTLV, collateral, feeRate, locktime, refundLT, payoutAddress, changeAddress])).subscribe(r => {
-            console.warn('CreateDLCOffer()', r)
-            if (r.result) {
-              this.newOfferResult = r.result
-              // this.walletStateService.refreshDLCStates() // via websocket now
-              this.offerCreated = true
-            }
-            this.executing = false
-          })
+          this.handleContractInfo(r.result)
         }
-        
       })
     }
-    
+  }
+
+  private handleContractInfo(contractInfoTLV: string) {
+    const v = this.form.value
+    const collateral = v.yourCollateral
+    const feeRate = v.feeRate
+    const locktime = dateToSecondsSinceEpoch(new Date(this.event.maturity))
+    const refundLT = dateToSecondsSinceEpoch(v.refundDate)
+    const payoutAddress = v.externalPayoutAddress ? v.externalPayoutAddress.trim() : null
+    const changeAddress = null
+
+    console.debug('handleContractInfo() collateral:', collateral, 'feeRate:', feeRate, 'locktime:', locktime, 
+      'refundLT:', refundLT, 'payoutAddress:', payoutAddress, 'changeAddress:', changeAddress)
+
+    this.messageService.sendMessage(getMessageBody(WalletMessageType.createdlcoffer, 
+      [contractInfoTLV, collateral, feeRate, locktime, refundLT, payoutAddress, changeAddress])).subscribe(r => {
+      console.warn(' createdlcoffer', r)
+      if (r.result) {
+        this.newOfferResult = r.result
+        // this.walletStateService.refreshDLCStates() // via websocket now
+        this.offerCreated = true
+
+        if (this.offerType === OfferType.TOR) {
+          const v = this.typeForm.value
+          this.offerService.sendIncomingOffer(this.newOfferResult, v.peer, v.message).subscribe(r => {
+            console.warn(' sendIncomingOffer', r)
+            if (r.result) {
+
+            }
+          })
+        }
+      }
+      this.executing = false // Not exactly right
+    })
   }
 
   private buildPayoutVals() {

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
@@ -198,6 +198,7 @@ export class NewOfferComponent implements OnInit {
 
   executing = false
   offerCreated = false
+  offerSent = false
 
   newOfferResult: string = ''
 
@@ -395,10 +396,11 @@ export class NewOfferComponent implements OnInit {
 
         if (this.offerType === OfferType.TOR) {
           const v = this.typeForm.value
+          // TODO : This needs to run on offer.temporaryContractId
           this.offerService.sendIncomingOffer(this.newOfferResult, v.peerAddress, v.message).subscribe(r => {
             console.warn(' sendIncomingOffer', r)
             if (r.result) {
-
+              this.offerSent = true
             }
           })
         }

--- a/wallet-server-ui/src/app/component/offers/offers.component.html
+++ b/wallet-server-ui/src/app/component/offers/offers.component.html
@@ -10,7 +10,7 @@
           <mat-form-field>
             <textarea matInput formControlName="message" cdkTextareaAutosize
               placeholder="{{ 'offers.message' | translate }}" type="text" maxlength="1024" autocomplete="off"
-              (paste)="messageValue = trimOnPaste($event)">
+              (paste)="onMessagePaste($event)">
             </textarea>
           </mat-form-field>
           <mat-form-field>

--- a/wallet-server-ui/src/app/component/offers/offers.component.ts
+++ b/wallet-server-ui/src/app/component/offers/offers.component.ts
@@ -33,6 +33,7 @@ export class OffersComponent implements OnInit, AfterViewInit, OnDestroy {
   // New Incoming Offer
   form: FormGroup
   get f() { return this.form.controls }
+  get messageValue() { return this.form.get('message')?.value }
   set messageValue(message: string) { this.form.patchValue({ message }) }
   set peerValue(peer: string) { this.form.patchValue({ peer }) }
   set offerTLVValue(offerTLV: string) { this.form.patchValue({ offerTLV }) }
@@ -121,6 +122,11 @@ export class OffersComponent implements OnInit, AfterViewInit, OnDestroy {
       return offer.offer.contractInfo.totalCollateral - offer.offer.offerCollateral
     }
     return undefined
+  }
+
+  onMessagePaste(event: ClipboardEvent) {
+    // Only trimOnPaste() if there is no value in the field already
+    if (!this.messageValue) this.messageValue = trimOnPaste(event)
   }
 
   addManualOffer() {

--- a/wallet-server-ui/src/app/component/offers/offers.component.ts
+++ b/wallet-server-ui/src/app/component/offers/offers.component.ts
@@ -69,8 +69,8 @@ export class OffersComponent implements OnInit, AfterViewInit, OnDestroy {
       })
     this.form = this.formBuilder.group({
       message: [''],
-      peer: ['', Validators.compose([regexValidator(TOR_V3_ADDRESS), Validators.required])],
-      offerTLV: ['', Validators.compose([regexValidator(UPPERLOWER_CASE_HEX), Validators.required])],
+      peer: ['', [Validators.required, regexValidator(TOR_V3_ADDRESS)]],
+      offerTLV: ['', [Validators.required, regexValidator(UPPERLOWER_CASE_HEX)]],
     })
   }
 

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -169,7 +169,12 @@
     "advanced": "Advanced",
     "externalPayoutAddress": "External Payout Address",
     "createOffer": "Create Offer",
-    "offerCreated": "Offer Created"
+    "offerCreated": "Offer Created",
+    "offerType": {
+      "tor": "Tor",
+      "text": "Text"
+    },
+    "message": "Message"
   },
 
   "newOfferDescription": {
@@ -178,9 +183,14 @@
     "totalCollateral": "Total contract collateral (sats)",
     "feeRate": "Fee Rate built into contract (sats/vbyte)",
     "refundDate": "When the contract can be refunded",
-    "createOffer": "Create this DLC Offer in your wallet and reserve funds.",
-    "createOffer2": "You will send the hex string representing your offer in Result below to your counterparty along with your Tor DLC Host Address to complete the contract.",
-    "externalPayoutAddress": "Use Payout Address outside of the Suredbits Wallet"
+    "createOffer": "Create this DLC offer in your wallet and reserve funds. You'll exchange this offer with your counterparty over Tor or with saved text.",
+    "externalPayoutAddress": "Use Payout Address outside of the Suredbits Wallet",
+    "offerType": {
+      "tor": "Use Tor to pass messages. Your counterparty needs to be online and share their Tor DLC Host Address with you. Your counterparty will receive this offer in their Offers list.",
+      "text": "You will send the hex string representing your offer in Result below to your counterparty along with your Tor DLC Host Address to complete the contract."
+    },
+    "message": "Message to your counterparty",
+    "peerAddress": "Tor DLC Host Address of the person you'd like to complete the contract with. Putting an address in here will attempt to complete the remaining contract steps online."
   },
 
   "newOfferValidation": {

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -311,6 +311,8 @@
     "pnl": "Profit or Loss",
     "rateOfReturn": "Rate of Return",
 
+    "sendToCounterparty": "Send to Counterparty",
+
     "signAcceptOffer": "Sign Accepted Offer",
     "filename": "Filename",
     "defaultSignFilename": "Signed DLC Accept.txt",

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -170,6 +170,7 @@
     "externalPayoutAddress": "External Payout Address",
     "createOffer": "Create Offer",
     "offerCreated": "Offer Created",
+    "offerSent": "Offer Sent",
     "offerType": {
       "tor": "Tor",
       "text": "Text"

--- a/wallet-server-ui/src/service/offer-service.ts
+++ b/wallet-server-ui/src/service/offer-service.ts
@@ -118,8 +118,8 @@ export class OfferService {
     }
   }
 
-  sendIncomingOffer(offerTLV: string, peer: string, message: string) {
-    return this.messageService.sendMessage(getMessageBody('offer-send', [offerTLV, peer, message]))
+  sendIncomingOffer(offerTLVorTempId: string, peer: string, message: string) {
+    return this.messageService.sendMessage(getMessageBody('offer-send', [offerTLVorTempId, peer, message]))
     .pipe(tap(r => {
       console.debug('offer-send', r)
       if (r.result) { // hash.hex

--- a/wallet-server-ui/src/styles.scss
+++ b/wallet-server-ui/src/styles.scss
@@ -37,6 +37,10 @@ fieldset {
   }
 }
 
+[hidden] {
+  display: none !important;
+}
+
 /** Text Align */
 .text-center {
   text-align: center;

--- a/wallet-server-ui/src/styles.scss
+++ b/wallet-server-ui/src/styles.scss
@@ -261,6 +261,7 @@ mat-form-field {
 
 .execute-container {
   margin-top: 2rem;
+  margin-bottom: 0.5rem;
   
   .button-group {
     display: flex;


### PR DESCRIPTION
This runs over https://github.com/bitcoin-s/bitcoin-s/pull/4153

Implements `offer-send` RPC endpoint functionality from New Offer sidebar adding offer to remote counterparty's `offers-list`.

I tested several sent and received offers between Mac and x64, tested with external payout address, and tested traditional exchange (now 'Text'), tested with recipient offline, tested re-send same offer.

![Screen Shot 2022-03-03 at 8 34 24 AM](https://user-images.githubusercontent.com/22351459/156598113-d76ab645-9e7b-47d0-bd83-47ccc975df9d.png)
![Screen Shot 2022-03-03 at 8 35 59 AM](https://user-images.githubusercontent.com/22351459/156598122-23ff431a-fc20-4a3a-84c2-55704097d429.png)
![Screen Shot 2022-03-03 at 3 23 49 PM](https://user-images.githubusercontent.com/22351459/156664352-26bcd268-c3f4-444d-ab83-6a3aac9810e7.png)

