### PR TITLE
Show DLC.payoutAddress and isExternal flag

### DIFF
--- a/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.scss
+++ b/wallet-server-ui/src/app/component/accept-offer/accept-offer.component.scss
@@ -114,7 +114,7 @@
   }
 
   .execute-container {
-    margin-bottom: 0.5rem;
+    padding-bottom: 0.5rem;
   }
 
 }

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -240,6 +240,17 @@
         </div>
       </ng-container>
 
+      <mat-form-field class="w-70">
+        <mat-label translate>contractDetail.payoutAddress</mat-label>
+        <input matInput [value]="dlc.payoutAddress.address" readonly>
+        <button *ngIf="dlc.payoutAddress.isExternal"
+          mat-icon-button matSuffix
+          matTooltip="{{ 'contractDetail.externalPayoutAddress' | translate:{address: dlc.payoutAddress.address} }}"
+          (click)="copyToClipboard(dlc.payoutAddress.address)">
+          <mat-icon>trending_up</mat-icon>
+        </button>
+      </mat-form-field>
+
     </fieldset>
   </form>
 

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.html
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.html
@@ -29,7 +29,7 @@
         <!-- Grouping row -->
         <ng-container matColumnDef="header-row-spacer-group">
           <th mat-header-cell *matHeaderCellDef 
-              [attr.colspan]="3">
+              [attr.colspan]="4">
           </th>
         </ng-container>
         <ng-container matColumnDef="header-row-return-group">
@@ -54,6 +54,19 @@
           <!-- Compiler Not happy with the following type of notation -->
           <td mat-cell *matCellDef="let contract">
             {{ getContractInfo(contract.dlcId)?.oracleInfo?.announcement?.event?.eventId }}
+          </td>
+        </ng-container>
+        <!-- Area for status flags or operation buttons -->
+        <ng-container matColumnDef="flags">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let contract">
+            <ng-container *ngIf="contract.payoutAddress && contract.payoutAddress.isExternal">
+              <button mat-icon-button class="mat-icon-button-sm"
+                matTooltip="{{ 'contracts.externalPayoutAddress' | translate:{address: contract.payoutAddress.address} }}"
+                (click)="copyToClipboard(contract.payoutAddress.address); $event.stopPropagation()">
+                <mat-icon class="mat-icon-sm material-icons-outlined">trending_up</mat-icon>
+              </button>
+            </ng-container>
           </td>
         </ng-container>
         <ng-container matColumnDef="contractId">

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.html
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.html
@@ -60,7 +60,7 @@
         <ng-container matColumnDef="flags">
           <th mat-header-cell *matHeaderCellDef></th>
           <td mat-cell *matCellDef="let contract">
-            <ng-container *ngIf="contract.payoutAddress && contract.payoutAddress.isExternal">
+            <ng-container *ngIf="contract.payoutAddress.isExternal">
               <button mat-icon-button class="mat-icon-button-sm"
                 matTooltip="{{ 'contracts.externalPayoutAddress' | translate:{address: contract.payoutAddress.address} }}"
                 (click)="copyToClipboard(contract.payoutAddress.address); $event.stopPropagation()">

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.ts
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.ts
@@ -47,7 +47,7 @@ export class ContractsComponent implements OnInit, AfterViewInit, OnDestroy {
 
   // Grid config
   dataSource = new MatTableDataSource(<DLCContract[]>[])
-  displayedColumns = ['eventId', 'contractId', 'state', 'realizedPNL', 'rateOfReturn', 
+  displayedColumns = ['eventId', 'flags', 'contractId', 'state', 'realizedPNL', 'rateOfReturn', 
     'totalCollateral', 'collateral', 'counterpartyCollateral', 'lastUpdated']
 
   private selectedDLCId: string|undefined

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -276,7 +276,8 @@
     "totalCollateral": "Total",
     "lastUpdated": "Updated",
     "noContracts": "No DLC Contracts Started",
-    "copyContractId": "Copy Contract Id to Clipboard"
+    "copyContractId": "Copy Contract Id to Clipboard",
+    "externalPayoutAddress": "External Payout Address: {{address}}"
   },
 
   "contractDetail": {
@@ -308,6 +309,8 @@
     "fundingRebroadcastSuccess": "Successfully rebroadcast funding transaction",
     "closingRebroadcastSuccess": "Successfully rebroadcast closing transaction",
     "refundContract": "Refund",
+    "payoutAddress": "Payout Address",
+    "externalPayoutAddress": "DLC payout address is outside this wallet",
     "viewOnOracleExplorer": "View on Oracle Explorer",
 
     "contractOutcome": "Payout",

--- a/wallet-server-ui/src/type/wallet-server-types.ts
+++ b/wallet-server-ui/src/type/wallet-server-types.ts
@@ -186,6 +186,7 @@ export interface DLCContract {
   state: DLCState // string //  "Offered"
   temporaryContractId: string // "ddb32c03280b4e064aad9815927f383c87b028a98c07f481e0941624e97d8924"
   totalCollateral: number // 200001
+  payoutAddress: { address: string, isExternal: boolean } // isExternal to wallet
 
   // not present initially
   contractId?: string

--- a/wallet-ts/lib/type/wallet-types.ts
+++ b/wallet-ts/lib/type/wallet-types.ts
@@ -130,6 +130,7 @@ export interface DLCContract {
   state: string // DLCState //  "Offered"
   temporaryContractId: string // "ddb32c03280b4e064aad9815927f383c87b028a98c07f481e0941624e97d8924"
   totalCollateral: number // 200001
+  payoutAddress: { address: string, isExternal: boolean } // isExternal to wallet
 
   // not present initially
   contractId?: string


### PR DESCRIPTION
Shows a flag for isExternal payoutAddresses in the Contract List and shows the payout address and flag for isExternal in Contract Details. Clicking isExternal icon will copy address to clipboard.

I'm not completely happy with icon, but seemed best of arrow type icons I looked at in material design icons.

![Screen Shot 2022-03-09 at 3 43 44 PM](https://user-images.githubusercontent.com/22351459/157554052-6b2fd1e1-2827-4583-99cd-dd5db0b041d2.png)
![Screen Shot 2022-03-09 at 4 01 28 PM](https://user-images.githubusercontent.com/22351459/157554060-bf87be20-21e7-4503-9b17-df8d46ee33f9.png)
