### PR TITLE
Upgrade docker base image to node:16.15-buster-slim

### DIFF
--- a/oracle-server-ui/Dockerfile
+++ b/oracle-server-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-buster-slim AS builder
+FROM node:16.15-buster-slim AS builder
 
 RUN apt-get update && apt-get install -y git python3 build-essential
 WORKDIR /build
@@ -9,7 +9,7 @@ RUN npm run build
 WORKDIR /build/oracle-server-ui-proxy
 RUN npm run build
 
-FROM node:16-buster-slim
+FROM node:16.15-buster-slim
 USER 1000
 WORKDIR /build
 COPY --from=builder /build .

--- a/wallet-server-ui/Dockerfile
+++ b/wallet-server-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-buster-slim AS builder
+FROM node:16.15-buster-slim AS builder
 
 RUN apt-get update && apt-get install -y git python3 build-essential
 WORKDIR /build
@@ -9,7 +9,7 @@ RUN npm run build
 WORKDIR /build/wallet-server-ui-proxy
 RUN npm run build
 
-FROM node:16-buster-slim
+FROM node:16.15-buster-slim
 USER 1000
 WORKDIR /build
 COPY --from=builder /build .


### PR DESCRIPTION
This is the error I see when trying to build `oracle-server-ui/Dockerfile` and `wallet-server-ui/Dockerfile` locally.

![Screenshot from 2022-05-16 13-58-10](https://user-images.githubusercontent.com/3514957/168664199-580b18f6-85ee-4bd8-8241-c7499fc7414f.png)

This PR upgrades the base docker image `node:16.15-buster-slim`