### PR TITLE
Add autoLogin behavior

### DIFF
--- a/oracle-server-ui/src/app/app.component.ts
+++ b/oracle-server-ui/src/app/app.component.ts
@@ -76,7 +76,7 @@ export class AppComponent implements OnInit, OnDestroy {
   private onLogout() {
     this.stateLoaded = false
     this.rightDrawer.close()
-    this.router.navigate(['/login'])
+    this.router.navigate(['/login'], { queryParams: { loggedOut: 1 } })
   }
 
   ngOnInit() {

--- a/oracle-server-ui/src/app/login/login.component.html
+++ b/oracle-server-ui/src/app/login/login.component.html
@@ -13,7 +13,8 @@
       </mat-form-field>
       <mat-form-field class="w-100">
         <mat-label translate>login.password</mat-label>
-        <input matInput name="password" formControlName="password" type="password" autocomplete="current-password">
+        <input matInput name="password" formControlName="password" type="password" autocomplete="current-password"
+          [readonly]="autoLogin">
       </mat-form-field>
     </fieldset>
     <div class="button-group">

--- a/oracle-server-ui/src/environments/environment.prod.ts
+++ b/oracle-server-ui/src/environments/environment.prod.ts
@@ -8,5 +8,6 @@ export const environment = {
   blockstreamApi: '/blockstream',
   mempoolApi: '/mempool',
   user: 'frontend',
-  password: '',
+  password: 'none',
+  autoLogin: true,
 };

--- a/oracle-server-ui/src/environments/environment.ts
+++ b/oracle-server-ui/src/environments/environment.ts
@@ -13,6 +13,7 @@ export const environment = {
   mempoolApi: '/mempool',
   user: 'frontend',
   password: 'none',
+  autoLogin: true,
 };
 
 /*

--- a/oracle-server-ui/src/service/auth.service.ts
+++ b/oracle-server-ui/src/service/auth.service.ts
@@ -25,6 +25,17 @@ export class AuthService {
   expiration: Date|null|undefined = undefined
   loginTime$: Subscription
 
+  public get isLoggedIn() {
+    if (this.expiration) {
+      return this.expiration.getTime() >= new Date().getTime()
+    }
+    return false
+  }
+
+  public get isLoggedOut() {
+    return !this.isLoggedIn
+  }
+
   loggedIn: EventEmitter<void> = new EventEmitter()
   loggedOut: EventEmitter<void> = new EventEmitter()
 
@@ -155,17 +166,6 @@ export class AuthService {
 
   public getToken() {
     return localStorage.getItem(ACCESS_TOKEN_KEY)
-  }
-
-  public get isLoggedIn() {
-    if (this.expiration) {
-      return this.expiration.getTime() >= new Date().getTime()
-    }
-    return false
-  }
-
-  public get isLoggedOut() {
-    return !this.isLoggedIn
   }
 
 }

--- a/wallet-server-ui/src/app/app.component.ts
+++ b/wallet-server-ui/src/app/app.component.ts
@@ -67,7 +67,7 @@ export class AppComponent implements OnInit, OnDestroy {
     this.websocketService.stopPolling()
     this.stateLoaded = false
     this.rightDrawer.close()
-    this.router.navigate(['/login'])
+    this.router.navigate(['/login'], { queryParams: { loggedOut: 1 } })
   }
 
   ngOnInit(): void {

--- a/wallet-server-ui/src/app/component/login/login.component.html
+++ b/wallet-server-ui/src/app/component/login/login.component.html
@@ -13,7 +13,8 @@
       </mat-form-field>
       <mat-form-field class="w-100">
         <mat-label translate>login.password</mat-label>
-        <input matInput name="password" formControlName="password" type="password" autocomplete="current-password">
+        <input matInput name="password" formControlName="password" type="password" autocomplete="current-password"
+          [readonly]="autoLogin">
       </mat-form-field>
     </fieldset>
     <div class="button-group">

--- a/wallet-server-ui/src/app/component/login/login.component.ts
+++ b/wallet-server-ui/src/app/component/login/login.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit } from '@angular/core'
+import { Component, OnDestroy, OnInit } from '@angular/core'
 import { FormBuilder, FormGroup, Validators } from '@angular/forms'
-import { Router } from '@angular/router'
+import { ActivatedRoute, Params, Router } from '@angular/router'
+import { Subscription } from 'rxjs'
 
 import { environment } from '../../../environments/environment'
 
@@ -17,11 +18,12 @@ import { getMessageBody } from '~util/wallet-server-util'
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss']
 })
-export class LoginComponent implements OnInit {
+export class LoginComponent implements OnInit, OnDestroy {
 
   public AlertType = AlertType
   
   debug = environment.debug // flag for debugging buttons
+  autoLogin = environment.autoLogin
 
   form: FormGroup
 
@@ -29,19 +31,30 @@ export class LoginComponent implements OnInit {
   loginExecuting = false
 
   error: any
+  queryParams$: Subscription
 
-  constructor(private fb: FormBuilder, public authService: AuthService, private router: Router,
+  constructor(private fb: FormBuilder, private route: ActivatedRoute,
+    public authService: AuthService, private router: Router,
     private messageService: MessageService) { }
 
   ngOnInit(): void {
+    this.queryParams$ = this.route.queryParams
+      .subscribe((params: Params) => {
+        // If logout was set by application, break out of autoLogin cycle
+        if (params.loggedOut) this.autoLogin = false
+      })
     this.form = this.fb.group({
       user: [environment.user, Validators.required],
       password: [environment.password, Validators.required],
     })
-    // if (environment.autoLogin && this.authService.expiration === undefined) {
-    //   console.debug('autoLogin')
-    //   this.login()
-    // }
+    if (this.autoLogin && this.authService.isLoggedOut) {
+      console.warn('autoLogin')
+      this.login()
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.queryParams$) this.queryParams$.unsubscribe()
   }
 
   private errorHandler(err: any) {

--- a/wallet-server-ui/src/environments/environment.prod.ts
+++ b/wallet-server-ui/src/environments/environment.prod.ts
@@ -5,5 +5,6 @@ export const environment = {
   proxyApi: '/proxy/v0',
   wsApi: '/websocket',
   user: 'frontend',
-  password: '',
+  password: 'none',
+  autoLogin: true,
 };

--- a/wallet-server-ui/src/environments/environment.ts
+++ b/wallet-server-ui/src/environments/environment.ts
@@ -10,6 +10,7 @@ export const environment = {
   wsApi: '/websocket',
   user: 'frontend',
   password: 'none',
+  autoLogin: true,
 };
 
 /*

--- a/wallet-server-ui/src/service/auth.service.ts
+++ b/wallet-server-ui/src/service/auth.service.ts
@@ -25,6 +25,17 @@ export class AuthService {
   expiration: Date|null|undefined = undefined
   loginTime$: Subscription
 
+  public get isLoggedIn() {
+    if (this.expiration) {
+      return this.expiration.getTime() >= new Date().getTime()
+    }
+    return false
+  }
+
+  public get isLoggedOut() {
+    return !this.isLoggedIn
+  }
+
   loggedIn: EventEmitter<void> = new EventEmitter()
   loggedOut: EventEmitter<void> = new EventEmitter()
 
@@ -155,17 +166,6 @@ export class AuthService {
 
   public getToken() {
     return localStorage.getItem(ACCESS_TOKEN_KEY)
-  }
-
-  public get isLoggedIn() {
-    if (this.expiration) {
-      return this.expiration.getTime() >= new Date().getTime()
-    }
-    return false
-  }
-
-  public get isLoggedOut() {
-    return !this.isLoggedIn
   }
 
 }


### PR DESCRIPTION
Adds automatic login flag for UI project configs and sets to true. The user is still allowed to log out and login timer/session length is left as previously.

Tested working well in local startproxy/startlocal and electron project builds.

To run this on Umbrel, We will change the `environment` flags on the docker-compose.yml files like:
DEFAULT_UI_PASSWORD: "none"
BITCOIN_S_SERVER_RPC_PASSWORD: "none" / BITCOIN_S_ORACLE_RPC_PASSWORD: "none"