### PR TITLE
Disable autoLogin to unlock password entry on login error

### DIFF
--- a/wallet-server-ui/src/app/component/login/login.component.ts
+++ b/wallet-server-ui/src/app/component/login/login.component.ts
@@ -74,6 +74,8 @@ export class LoginComponent implements OnInit, OnDestroy {
     this.executing = false
     this.loginExecuting = false
     this.error = err.error
+    // Force autoLogin false after an error in case loggedOut flag didn't get set
+    this.autoLogin = false
   }
 
   login() {

--- a/wallet-server-ui/src/service/auth.service.ts
+++ b/wallet-server-ui/src/service/auth.service.ts
@@ -69,15 +69,22 @@ export class AuthService {
     return this.http.post<LoginResponse>(environment.proxyApi + `/auth/login`, { user, password })
       .pipe(tap(result => {
         this.doLogin(result)
-      }), shareReplay())
+      }))
   }
 
   logout() {
     const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY)
-    return this.http.post<any>(environment.proxyApi + `/auth/logout`, { refreshToken })
-      .pipe(tap(res => {
+    if (!refreshToken) {
+      console.warn('no refreshToken to logout with')
+      return of(<LoginResponse><unknown>null).pipe(tap(res => {
         this.doLogout()
-      }), shareReplay())
+      }))
+    } else {
+      return this.http.post<any>(environment.proxyApi + `/auth/logout`, { refreshToken })
+        .pipe(tap(res => {
+          this.doLogout()
+        }))
+    }
   }
 
   authTest() {


### PR DESCRIPTION
Trying to get to the root of @CypherPoet's issue.

I think there's a scenario when the refreshToken could have been unset, causing an error to throw, and the route not to change to include` loggedOut`, and autoLogin not unsetting. This case should be covered in logout().

This also unsets autoLogin on any error, which may be over-broad, but seems like a good fallback if the initial analysis is wrong.