### PR TITLE
Add isinitialblockdownload flag to getinfo, show in network and header

### DIFF
--- a/wallet-server-ui/src/app/app.component.ts
+++ b/wallet-server-ui/src/app/app.component.ts
@@ -69,7 +69,8 @@ export class AppComponent implements OnInit, OnDestroy {
 
   private onLogout() {
     this.destroySubscriptions()
-    this.appServerReady$.unsubscribe()
+    if (this.appServerReady$)
+      this.appServerReady$.unsubscribe()
     this.walletStateService.uninitialize()
     this.websocketService.stopPolling()
     this.stateLoaded = false

--- a/wallet-server-ui/src/app/component/header/header.component.html
+++ b/wallet-server-ui/src/app/component/header/header.component.html
@@ -172,20 +172,27 @@
         <!-- </div> -->
       </a>
 
-      <!-- Tor Starting indicator -->
-      <mat-icon *ngIf="walletStateService.info?.torStarted === false" class="tor-starting" 
-        matTooltip="{{ 'header.torStarting' | translate }}"
-        matTooltipPosition="before">sync_disabled</mat-icon>
+      <ng-container *ngIf="walletStateService.info">
+        <!-- Tor Starting indicator -->
+        <mat-icon *ngIf="walletStateService.info.torStarted === false" class="tor-starting" 
+          matTooltip="{{ 'header.torStarting' | translate }}"
+          matTooltipPosition="below">sync_disabled</mat-icon>
 
-      <!-- Blockchain syncing indicator -->
-      <mat-icon *ngIf="walletStateService.info?.syncing" class="syncing" 
-        matTooltip="{{ 'header.syncing' | translate }}"
-        matTooltipPosition="before">sync_cloud</mat-icon>
+        <!-- Initial Block Download indicator -->
+        <mat-icon *ngIf="walletStateService.info.isinitialblockdownload" class="initial-block-download" 
+          matTooltip="{{ 'header.initialBlockDownload' | translate }}"
+          matTooltipPosition="below">cloud_sync</mat-icon>
+
+        <!-- Blockchain syncing indicator -->
+        <mat-icon *ngIf="walletStateService.info.syncing && !walletStateService.info.isinitialblockdownload" class="syncing" 
+          matTooltip="{{ 'header.syncing' | translate }}"
+          matTooltipPosition="below">sync</mat-icon>
+      </ng-container>
       
       <!-- Wallet rescanning indicator -->
-      <mat-icon *ngIf="walletStateService.wallet.value?.rescan" class="syncing" 
+      <mat-icon *ngIf="walletStateService.wallet.value?.rescan" class="rescanning" 
         matTooltip="{{ 'header.rescanning' | translate }}"
-        matTooltipPosition="before">sync_lock</mat-icon>
+        matTooltipPosition="below">sync_lock</mat-icon>
 
       <!--
       <div class="indicator-padding"></div>

--- a/wallet-server-ui/src/app/component/header/header.component.scss
+++ b/wallet-server-ui/src/app/component/header/header.component.scss
@@ -64,7 +64,7 @@ $appLogoSize: 30px;
       margin-bottom: 0.1rem;
     }
   }
-  .tor-starting, .syncing {
+  .tor-starting, .initial-block-download, .syncing, .rescanning {
     margin-left: 0.5rem;
     margin-right: 0.5rem;
     animation: blink 2s ease-in infinite;

--- a/wallet-server-ui/src/app/component/network/network.component.html
+++ b/wallet-server-ui/src/app/component/network/network.component.html
@@ -10,27 +10,36 @@
     <div class="block-height"
       translate="status.blockHeightLabel" 
       [translateParams]="{ height: formatNumber(walletStateService.info.blockHeight) }"></div>
-    <div *ngIf="walletStateService.info" class="syncing">
-      <label translate>network.syncing</label>
-      <input type="checkbox" [checked]="walletStateService.info.syncing" disabled>
-    </div>
     <div class="fee-estimate" 
       translate="status.feeEstimateLabel"
       [translateParams]="{ fee: walletStateService.feeEstimate }"></div>
+  </div>
 
-    <div class="tor-container">
-      <div *ngIf="walletStateService.info" class="tor-started">
-        <label translate>network.torStarted</label>
-        <input type="checkbox" [checked]="walletStateService.info.torStarted" disabled>
-      </div>
-      <div *ngIf="walletStateService.torDLCHostAddress" class="tor-dlc-host-address">
-        <label translate>network.torDLCHostAddress</label>
-        <input [value]="walletStateService.torDLCHostAddress" disabled>
-        <button mat-icon-button class="copy-button mat-icon-button-sm" matTooltip="{{ 'action.copyToClipboard' | translate }}"
-          (click)="copyToClipboard(walletStateService.torDLCHostAddress)">
-          <mat-icon class="mat-icon-sm">content_copy</mat-icon>
-        </button>
-      </div>
+  <div class="tor-container">
+    <label translate>status.tor</label>
+    <div *ngIf="walletStateService.info" class="tor-started">
+      <label translate>network.torStarted</label>
+      <input type="checkbox" [checked]="walletStateService.info.torStarted" disabled>
+    </div>
+    <div *ngIf="walletStateService.torDLCHostAddress" class="tor-dlc-host-address">
+      <label translate>network.torDLCHostAddress</label>
+      <input [value]="walletStateService.torDLCHostAddress" disabled>
+      <button mat-icon-button class="copy-button mat-icon-button-sm" matTooltip="{{ 'action.copyToClipboard' | translate }}"
+        (click)="copyToClipboard(walletStateService.torDLCHostAddress)">
+        <mat-icon class="mat-icon-sm">content_copy</mat-icon>
+      </button>
+    </div>
+  </div>
+
+  <div class="server-container">
+    <label translate>status.serverState</label>
+    <div *ngIf="walletStateService.info" class="initial-block-download">
+      <label translate>network.initialBlockDownload</label>
+      <input type="checkbox" [checked]="walletStateService.info.isinitialblockdownload" disabled>
+    </div>
+    <div *ngIf="walletStateService.info" class="syncing">
+      <label translate>network.syncing</label>
+      <input type="checkbox" [checked]="walletStateService.info.syncing" disabled>
     </div>
   </div>
 

--- a/wallet-server-ui/src/app/component/network/network.component.scss
+++ b/wallet-server-ui/src/app/component/network/network.component.scss
@@ -1,39 +1,31 @@
 .network-section {
 
-  .network-content {
+  .network-content, .tor-container, .server-container, .data-connection {
     display: flex;
     flex-direction: column;
-    margin: 0 1rem 1rem 1rem;
+    margin: 0 1rem 1.5rem 1rem;
 
-    .network, .syncing, .block-height, .fee-estimate {
-      margin-bottom: 0.5rem;
-    }
-
-    .tor-container {
-      margin-top: 1rem;
-      margin-bottom: 1rem;
-
-      .tor-started, .tor-dlc-host-address {
-        
-      }
+    > label {
+      margin-bottom: 0.75rem;
+      font-size: larger;
     }
 
     label {
       margin-right: 0.5rem;
     }
-  }
 
-  .data-connection {
-    display: flex;
-    flex-direction: column;
-    margin: 0 1rem 1rem 1rem;
-
-    label {
-      margin-bottom: 0.75rem;
-      font-size: larger;
+    .network, .block-height, .fee-estimate {
+      margin-bottom: 0.5rem;
     }
+
+    .initial-block-download, .syncing,
+    .tor-started, .tor-dlc-host-address {
+      margin-bottom: 0.5rem;
+    }
+
     .server, .websocket {
       margin-bottom: 0.5rem;
     }
   }
+  
 }

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -30,6 +30,7 @@
     "walletBalance": "Wallet Balance (sats)\n\nConfirmed:\t{{confirmed}}\nUnconfirmed:\t{{unconfirmed}}\nReserved:\t{{reserved}}\nTotal:\t\t{{total}}",
     "networkStatus": "Network Status\n\nNetwork:\t{{network}}\nBlock Height:\t{{blockHeight}}\nFee Estimate:\t{{fee}} sats/vbyte",
     "torStarting": "Tor Starting",
+    "initialBlockDownload": "Initial Block Download",
     "syncing": "Syncing Blockchain",
     "rescanning": "Rescanning Blockchain"
   },
@@ -38,6 +39,7 @@
     "heading": "Network",
     "torDLCHostAddress": "Tor DLC Host Address",
     "torStarted": "Tor Started",
+    "initialBlockDownload": "Initial Block Download",
     "syncing": "Syncing Blockchain"
   },
 
@@ -55,6 +57,8 @@
     "networkLabel": "Network: {{ network }}",
     "blockHeightLabel": "Block Height: {{ height }}",
     "feeEstimateLabel": "Fee Estimate: {{ fee }} sats/vbyte",
+    "tor": "Tor",
+    "serverState": "Server State",
     "dataConnection": "Data Connection",
     "serverLabel": "Server state: {{state}}",
     "websocketLabel": "Websocket state: {{state}}"

--- a/wallet-server-ui/src/service/wallet-state-service.ts
+++ b/wallet-server-ui/src/service/wallet-state-service.ts
@@ -356,7 +356,7 @@ export class WalletStateService {
     console.debug('getWalletInfo()')
 
     return this.messageService.sendMessage(getMessageBody(WalletMessageType.walletinfo), false).pipe(tap(r => {
-      console.debug(' getinfo', r)
+      console.debug(' walletinfo', r)
       if (r.error) {
         console.error('getWalletInfo() error', r.error)
       } else if (r.result) {

--- a/wallet-server-ui/src/service/wallet-state-service.ts
+++ b/wallet-server-ui/src/service/wallet-state-service.ts
@@ -90,6 +90,8 @@ export class WalletStateService {
       if (this.state !== WalletServiceState.server_ready) {
         console.warn('server_ready')
         this.initializeWallet().subscribe()
+        // Clear IBD flag
+        this.refreshBlockchainInfo().subscribe()
       }
       this.state = WalletServiceState.server_ready
     } else if (this.info && this.info.torStarted === true) {

--- a/wallet-server-ui/src/type/wallet-server-types.ts
+++ b/wallet-server-ui/src/type/wallet-server-types.ts
@@ -50,8 +50,9 @@ export interface GetInfoResponse {
   network: string // like 'test'
   blockHeight: number
   blockHash: string
+  isinitialblockdownload: boolean // Currently doing initial block download (IBD) to sync chain
   torStarted: boolean
-  syncing: boolean // Blockchain data is currently syncing
+  syncing: boolean // Blockchain data is currently syncing, goes true/false during syncs after IBD
 }
 
 // EO blockbhain-types.ts

--- a/wallet-server-ui/src/type/wallet-server-types.ts
+++ b/wallet-server-ui/src/type/wallet-server-types.ts
@@ -50,8 +50,8 @@ export interface GetInfoResponse {
   network: string // like 'test'
   blockHeight: number
   blockHash: string
-  isinitialblockdownload: boolean // Currently doing initial block download (IBD) to sync chain
   torStarted: boolean
+  isinitialblockdownload: boolean // Currently doing initial block download (IBD) to sync chain
   syncing: boolean // Blockchain data is currently syncing, goes true/false during syncs after IBD
 }
 

--- a/wallet-ts/lib/type/blockchain-types.ts
+++ b/wallet-ts/lib/type/blockchain-types.ts
@@ -30,5 +30,6 @@ export interface GetInfoResponse {
   blockHeight: number
   blockHash: string
   torStarted: boolean
-  syncing: boolean // Blockchain data is currently syncing
+  isinitialblockdownload: boolean // Currently doing initial block download (IBD) to sync chain
+  syncing: boolean // Blockchain data is currently syncing, goes true/false during syncs after IBD
 }


### PR DESCRIPTION
This adds the `isinitialblockdownload` to the `getinfo` response and shows in the header and on the network page. This doesn't change anything about the startup state machine.

![Screen Shot 2022-08-22 at 11 56 24 AM](https://user-images.githubusercontent.com/22351459/185987757-66805601-d08e-4277-af46-b81b34147636.png)
![Screen Shot 2022-08-22 at 11 56 36 AM](https://user-images.githubusercontent.com/22351459/185987769-700a1b5d-1325-4626-96bd-b67cd60153c8.png)

