### PR TITLE
Update tool tip on contract/offer dialogs to be 'Send to Contact'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13009,6 +13009,7 @@
       }
     },
     "oracle-server-ts": {
+      "name": "@bitcoin-s-ts/oracle-server-ts",
       "version": "1.9.2",
       "dependencies": {
         "common-ts": "file:../common-ts"
@@ -13163,6 +13164,7 @@
       "dev": true
     },
     "wallet-ts": {
+      "name": "@bitcoin-s-ts/wallet-ts",
       "version": "1.9.2",
       "dependencies": {
         "common-ts": "file:../common-ts"

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -174,7 +174,7 @@
         <input matInput readonly>
         <!-- Contact Selection -->
         <button mat-stroked-button matSuffix class="mat-stroked-icon-button-md" [matMenuTriggerFor]="contactMenu"
-          matTooltip="{{ 'contacts.sendToContact' | translate }}"
+          matTooltip="{{ 'contacts.selectContact' | translate }}"
           [disabled]="!contactService.contacts.value || contactService.contacts.value.length === 0">
           <mat-icon class="material-icons-outlined">person_add</mat-icon></button>
         <mat-menu #contactMenu="matMenu" xPosition="before">

--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.html
@@ -174,7 +174,7 @@
         <input matInput readonly>
         <!-- Contact Selection -->
         <button mat-stroked-button matSuffix class="mat-stroked-icon-button-md" [matMenuTriggerFor]="contactMenu"
-          matTooltip="{{ 'contacts.addContact' | translate }}"
+          matTooltip="{{ 'contacts.sendToContact' | translate }}"
           [disabled]="!contactService.contacts.value || contactService.contacts.value.length === 0">
           <mat-icon class="material-icons-outlined">person_add</mat-icon></button>
         <mat-menu #contactMenu="matMenu" xPosition="before">

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
@@ -249,7 +249,7 @@
             (paste)="peerAddressValue = trimAndStripHTTPOnPaste($event)">
           <!-- Contact Selection -->
           <button mat-stroked-button matSuffix class="mat-stroked-icon-button-md" [matMenuTriggerFor]="contactMenu"
-            matTooltip="{{ 'contacts.sendToContact' | translate }}"
+            matTooltip="{{ 'contacts.selectContact' | translate }}"
             [disabled]="!contactService.contacts.value || contactService.contacts.value.length === 0">
             <mat-icon class="material-icons-outlined">person_add</mat-icon></button>
           <mat-menu #contactMenu="matMenu" xPosition="before">

--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.html
@@ -249,7 +249,7 @@
             (paste)="peerAddressValue = trimAndStripHTTPOnPaste($event)">
           <!-- Contact Selection -->
           <button mat-stroked-button matSuffix class="mat-stroked-icon-button-md" [matMenuTriggerFor]="contactMenu"
-            matTooltip="{{ 'contacts.addContact' | translate }}"
+            matTooltip="{{ 'contacts.sendToContact' | translate }}"
             [disabled]="!contactService.contacts.value || contactService.contacts.value.length === 0">
             <mat-icon class="material-icons-outlined">person_add</mat-icon></button>
           <mat-menu #contactMenu="matMenu" xPosition="before">

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -411,6 +411,7 @@
   "contacts": {
     "heading": "Contacts",
     "addContact": "Add Contact",
+    "sendToContact": "Send to Contact",
     "removeContact": "Remove Contact",
     "alias": "Alias",
     "address": "Address",

--- a/wallet-server-ui/src/assets/i18n/en.json
+++ b/wallet-server-ui/src/assets/i18n/en.json
@@ -411,7 +411,7 @@
   "contacts": {
     "heading": "Contacts",
     "addContact": "Add Contact",
-    "sendToContact": "Send to Contact",
+    "selectContact": "Select Contact",
     "removeContact": "Remove Contact",
     "alias": "Alias",
     "address": "Address",


### PR DESCRIPTION
H/T to @benthecarman for finding this one. Previously it would be `Add Contact` which confused him as he didn't want to add a contac, he wanted to send to a contact.

![Screenshot from 2022-08-24 14-59-08](https://user-images.githubusercontent.com/3514957/186511970-22ab8918-c4d7-47a4-9a22-11065ec21b0c.png)
