### PR TITLE
Add /bitcoin-s docker volume to ui images

### DIFF
--- a/oracle-server-ui/Dockerfile
+++ b/oracle-server-ui/Dockerfile
@@ -10,6 +10,9 @@ RUN npm run build
 WORKDIR /build/oracle-server-ui-proxy
 RUN npm run build
 
+RUN ["mkdir", "-p", "/bitcoin-s"]
+VOLUME ["/bitcoin-s"]
+
 FROM node:16.15-buster-slim
 USER 1000
 WORKDIR /build

--- a/wallet-server-ui/Dockerfile
+++ b/wallet-server-ui/Dockerfile
@@ -11,6 +11,8 @@ WORKDIR /build/wallet-server-ui
 RUN npm run build
 WORKDIR /build/wallet-server-ui-proxy
 RUN npm run build
+RUN ["mkdir", "-p", "/bitcoin-s"]
+VOLUME ["/bitcoin-s"]
 
 FROM node:16.15-buster-slim
 # defaulting to local first uid


### PR DESCRIPTION
Companion to this PR: https://github.com/bitcoin-s/bitcoin-s/pull/4677

This now creates a volume for the UI images called `bitcoin-s` and should write all data that wants to persisted to the volume.

This requires modifying environment variables `LOG_PATH` and `BITCOIN_S_HOME` to be inside of the `/bitcoin-s` volume.

