### PR TITLE
Remove cetlocktime parameter

### DIFF
--- a/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
+++ b/wallet-server-ui/src/app/component/new-offer/new-offer.component.ts
@@ -383,7 +383,7 @@ export class NewOfferComponent implements OnInit {
     const v = this.form.value
     const collateral = v.yourCollateral
     const feeRate = v.feeRate
-    const locktime = dateToSecondsSinceEpoch(new Date(this.event.maturity))
+    const locktime = null //don't set locktime, see: https://github.com/bitcoin-s/bitcoin-s/issues/4721
     const refundLT = dateToSecondsSinceEpoch(v.refundDate)
     const payoutAddress = v.externalPayoutAddress ? v.externalPayoutAddress.trim() : null
     const changeAddress = null

--- a/wallet-ts/lib/index.ts
+++ b/wallet-ts/lib/index.ts
@@ -303,13 +303,13 @@ export function CancelDLC(sha256hash: string) {
 // ContractInfoV0TLV
 // collateral in sats
 // feeRate in sats / vbyte
-export function CreateDLCOffer(contractInfoTLV: string, collateral: number, feeRate: number, locktime: number, refundLT: number) {
-  console.debug('CreateDLCOffer()', contractInfoTLV, collateral, feeRate, locktime, refundLT)
+export function CreateDLCOffer(contractInfoTLV: string, collateral: number, feeRate: number, refundLT: number) {
+  console.debug('CreateDLCOffer()', contractInfoTLV, collateral, feeRate, refundLT)
   validateString(contractInfoTLV, 'CreateDLCOffer()', 'contractInfoTLV')
   validateNumber(collateral, 'CreateDLCOffer()', 'collateral')
   validateNumber(feeRate, 'CreateDLCOffer()', 'feeRate')
-  validateNumber(locktime, 'CreateDLCOffer()', 'locktime')
   validateNumber(refundLT, 'CreateDLCOffer()', 'refundLT')
+  const locktime = null //don't set locktime, see: https://github.com/bitcoin-s/bitcoin-s/issues/4721
 
   const m = getMessageBody(WalletMessageType.createdlcoffer, [contractInfoTLV, collateral, feeRate, locktime, refundLT])
   return SendServerMessage(m).then(response => {


### PR DESCRIPTION
fixes https://github.com/bitcoin-s/bitcoin-s/issues/4721

We added the ability in https://github.com/bitcoin-s/bitcoin-s/pull/4285 to not pass a cet locktime. This is because in certain instances, an oracle attests to the outcome before the locktime on the bitcoin transactions. When a user attempts to settle the bet, they get the error cited in https://github.com/bitcoin-s/bitcoin-s/issues/4721