### PR TITLE
Make PNL red and green on Contracts, Fix PNL sorting bug

### DIFF
--- a/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.scss
+++ b/wallet-server-ui/src/app/component/contract-detail/contract-detail.component.scss
@@ -81,18 +81,12 @@
   }
 
   .payout-group {
-    .profit {
-      color: darkgreen;
-    }
-    .loss {
-      color: #C11B17; // chilli peper
-    }
-    .arrow-icon {
-      vertical-align: middle;
-    }
-    .rate-of-return {
-      font-size: -1;
-    }
+    // .arrow-icon {
+    //   vertical-align: middle;
+    // }
+    // .rate-of-return {
+    //   font-size: -1;
+    // }
   }
   .outcome-group {
     margin-top: 0.5rem;

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.html
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.html
@@ -115,7 +115,14 @@
         </ng-container>
         <ng-container matColumnDef="realizedPNL">
           <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'contracts.realizedPNL' | translate }}</th>
-          <td mat-cell class="numeric-cell" *matCellDef="let contract">{{ formatNumber(contract.pnl) }}</td>
+          <td mat-cell *matCellDef="let contract">
+            <div class="pnl-container">
+              <mat-icon *ngIf="contract.pnl > 0" matPrefix class="arrow-icon profit">arrow_drop_up</mat-icon>
+              <mat-icon *ngIf="contract.pnl < 0" matPrefix class="arrow-icon loss">arrow_drop_down</mat-icon>
+              <mat-icon *ngIf="contract.pnl === 0" matPrefix class="arrow-icon even">trending_flat</mat-icon>
+              <span [class.profit]="contract.pnl > 0" [class.loss]="contract.pnl < 0">{{ formatNumber(contract.pnl) }}</span>
+            </div>
+          </td>
         </ng-container>
         <ng-container matColumnDef="rateOfReturn">
           <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'contracts.rateOfReturn' | translate }}</th>

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.scss
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.scss
@@ -119,6 +119,11 @@ $padding: 0.5rem;
     .mat-cell.mat-column-contractId {
       white-space: nowrap;
     }
+    .pnl-container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
 
     // Hide Outcomes and Attestations on narrow screens
     @include lt-lg {

--- a/wallet-server-ui/src/app/component/contracts/contracts.component.ts
+++ b/wallet-server-ui/src/app/component/contracts/contracts.component.ts
@@ -101,9 +101,11 @@ export class ContractsComponent implements OnInit, AfterViewInit, OnDestroy {
     this.dataSource.sortingDataAccessor = (dlc: DLCContract, property: string) => {
       switch (property) {
         case 'eventId':
-          return this.getContractInfo(dlc.dlcId)?.oracleInfo?.announcement?.event?.eventId;
+          return this.getContractInfo(dlc.dlcId)?.oracleInfo?.announcement?.event?.eventId
+        case 'realizedPNL':
+          return dlc.pnl
         default:
-          return (<any>dlc)[property];
+          return (<any>dlc)[property]
       }
     }
     this.dataSource.sort = this.sort

--- a/wallet-server-ui/src/styles.scss
+++ b/wallet-server-ui/src/styles.scss
@@ -393,10 +393,10 @@ mat-form-field {
   vertical-align: middle;
 }
 .profit {
-  color: darkgreen;
+  color: forestgreen;
 }
 .loss {
-  color: #C11B17; // chili pepper
+  color: crimson;
 }
 .even {
   // no styling yet

--- a/wallet-server-ui/src/styles.scss
+++ b/wallet-server-ui/src/styles.scss
@@ -387,3 +387,17 @@ mat-form-field {
     }
   }
 }
+
+/** Global PNL Styling */
+.arrow-icon {
+  vertical-align: middle;
+}
+.profit {
+  color: darkgreen;
+}
+.loss {
+  color: #C11B17; // chili pepper
+}
+.even {
+  // no styling yet
+}


### PR DESCRIPTION
Fixes a PNL column sorting bug on Contracts and adds red/green arrows and color from Contract Details.
![Screen Shot 2022-09-09 at 12 49 08 PM](https://user-images.githubusercontent.com/22351459/189423162-325412f1-86ec-4ba7-987f-06117c3c0742.png)
