### PR TITLE
Move oracle-server-ui initialization into oracle-server-ts

### DIFF
--- a/common-ts/lib/index.ts
+++ b/common-ts/lib/index.ts
@@ -1,4 +1,5 @@
-import needle from 'needle'
+// Native fetch is not recognized by compiler yet despite the @types/node: 18.x
+declare function fetch(url: any, options: any): Promise<any>
 
 import { ServerMessage } from './type/server-message.js'
 import { MessageType, ServerResponse, VersionResponse } from './type/server-types'
@@ -10,6 +11,8 @@ import { validateString } from './util/validation-util.js'
 let SERVER_URL = 'http://localhost:9999/' // default to bitcoin-s server
 let AUTHORIZATION_HEADER = '' // default to no auth
 
+const DEBUG = true // log actions in console.debug
+
 /** Set Wallet Server endpoint */
 export function ConfigureServerURL(url: string): void {
   console.debug('ConfigureServerURL()', url)
@@ -20,35 +23,51 @@ export function ConfigureAuthorizationHeader(header: string): void {
   console.debug('ConfigureAuthorizationHeader()', header)
   AUTHORIZATION_HEADER = header
 }
-// Convenience function
+/** Set Authorization Header from user and password strings */
 export function ConfigureAuthorizationHeaderFromUserPassword(user: string, password: string): void {
   console.debug('ConfigureAuthorizationHeader()', user)
   AUTHORIZATION_HEADER = 'Basic ' + Buffer.from(`${user}:${password}`).toString('base64')
 }
 
 /** Send any ServerMessage */
-export function SendServerMessage(message: ServerMessage): any {
+export function SendServerMessage(message: ServerMessage, customConfig = {}): Promise<ServerResponse<any>> {
   if (message) {
-    const options: any = { json: true }
-    if (AUTHORIZATION_HEADER) options.headers = { 'Authorization': AUTHORIZATION_HEADER }
-    return needle('post', `${SERVER_URL}`, message, options).then(response => {
-      const body = <ServerResponse<any>>response.body
-      // Throw backend error to break promise chain for catch handling
-      if (body.error) throw(body.error)
-      return body
-    }).catch(err => {
-      console.error('SendServerMessage() error', err)
-      throw(err)
-    })
+    const headers: any = { 'Content-Type': 'application/json' }
+    if (AUTHORIZATION_HEADER) headers['Authorization'] = AUTHORIZATION_HEADER
+    const config: any = {
+      method: 'POST',
+      // mode: 'no-cors', // 'same-origin',
+      ...customConfig,
+      headers: {
+        ...headers,
+      },
+      body: JSON.stringify(message)
+    }
+
+    // console.debug('config:', config)
+
+    return fetch(`${SERVER_URL}`, config)
+      .then(async response => {
+        // if (response.status === 401) {
+        //   // autologout / redirect
+        // }
+        if (response.ok) {
+          return <ServerResponse<any>> await response.json()
+        } else {
+          const errorMessage = await response.text()
+          return Promise.reject(new Error(errorMessage))
+        }
+      })
   } else {
-    throw(Error('SendServerMessage() null message'))
+    return Promise.reject(Error('SendServerMessage() null message'))
   }
 }
 
 /** Common bitcoin-s message functions */ 
 
-export function GetVersion() {
-  console.debug('GetVersion()')
+/** Get Server Version */
+export function GetVersion(): Promise<ServerResponse<VersionResponse>> {
+  if (DEBUG) console.debug('GetVersion()')
 
   const m = getMessageBody(MessageType.getversion)
   return SendServerMessage(m).then(response => {
@@ -56,8 +75,9 @@ export function GetVersion() {
   })
 }
 
+/** Zip Server DataDir */
 export function ZipDataDir(path: string) {
-  console.debug('ZipDataDir()')
+  if (DEBUG) console.debug('ZipDataDir()')
   validateString(path, 'ZipDataDir()', 'path')
 
   const m = getMessageBody(MessageType.zipdatadir, [path])
@@ -67,4 +87,54 @@ export function ZipDataDir(path: string) {
   })
 }
 
-// export default [ConfigureWalletServerURL, SendOracleMessage, GetVersion]
+/** New Observable functions */
+
+// import { BehaviorSubject, forkJoin, from, of, timer } from 'rxjs'
+// import { delayWhen, retryWhen, switchMap, tap } from 'rxjs/operators'
+
+// const OFFLINE_POLLING_TIME = 5000 // ms
+
+// Detect that backend is available and ready for interaction
+// export function WaitForServer() {
+//   console.debug('WaitForServer()')
+//   return from(GetVersion()).pipe(
+//     retryWhen(errors => {
+//       return errors.pipe(
+//         tap(_ => { if (DEBUG) console.debug('polling server') }),
+//         delayWhen(_ => timer(OFFLINE_POLLING_TIME)),
+//       );
+//     }),
+//     tap(version => {
+//       if (version.result) {
+//         if (DEBUG) console.debug('WaitForServer()', version.result.version)
+//         // Update state model
+//         const s = state.getValue()
+//         s.version = version.result.version
+//         state.next(s)
+//       }
+//     })
+//   )
+// }
+
+/** TODO : Inheritable Shared State Model? */
+
+// export interface CommonStateModel {
+//   version: string
+// }
+
+// export class CommonStateImpl implements CommonStateModel {
+//   version: string
+// }
+
+// const state = new BehaviorSubject<CommonStateModel>(new CommonStateImpl())
+// export const CommonState = state.asObservable()
+
+// export default {
+//   // ...ENTRY_POINTS
+//   ConfigureServerURL,
+//   ConfigureAuthorizationHeader,
+//   ConfigureAuthorizationHeaderFromUserPassword,
+//   SendServerMessage,
+//   GetVersion,
+//   ZipDataDir
+// };

--- a/common-ts/package.json
+++ b/common-ts/package.json
@@ -23,22 +23,22 @@
   },
   "typesVersions": {
     "*": {
-      "*": ["dist/mjs/*"]
+      "*": [
+        "dist/mjs/*"
+      ]
     }
   },
   "scripts": {
     "prepublish": "npm run build",
     "build": "tsc && ./fixup.sh",
-    "tests": "node --loader ts-node/esm --es-module-specifier-resolution=node ./lib/tests.ts"
+    "tests": "node --loader ts-node/esm --es-module-specifier-resolution=node --experimental-fetch ./lib/tests.ts"
   },
   "private": true,
   "dependencies": {
-    "express": "^4.17.1",
-    "needle": "^3.0.0"
+    "express": "^4.17.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
-    "@types/needle": "^2.5.2",
     "typescript": "^4.8.2"
   }
 }

--- a/common-ts/tsconfig.json
+++ b/common-ts/tsconfig.json
@@ -12,7 +12,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es6",                                     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ES2022",                                     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -25,7 +25,7 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    // "module": "ES2020",                                /* Specify what module code is generated. */
+    "module": "ES2022",                                /* Specify what module code is generated. */
     "rootDir": "lib",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */

--- a/oracle-server-ts/lib/index.ts
+++ b/oracle-server-ts/lib/index.ts
@@ -1,18 +1,216 @@
-import { SendServerMessage } from 'common-ts/index.js'
+import { BehaviorSubject, forkJoin, from, Observable, of, timer } from 'rxjs'
+import { delayWhen, retryWhen, switchMap, tap } from 'rxjs/operators'
+
+import { SendServerMessage, GetVersion } from 'common-ts/index.js'
+import { ServerResponse, VersionResponse } from 'common-ts/type/server-types'
 import { getMessageBody } from 'common-ts/util/message-util.js'
 import { validateISODateString, validateNumber, validateString } from 'common-ts/util/validation-util.js'
 
-import { MessageType, OracleEvent, OracleResponse } from './type/oracle-server-types'
+import { MessageType, OracleAnnouncement, OracleEvent, OracleResponse } from './type/oracle-server-types'
 import { validateEnumOutcomes } from './util/validation-util.js'
 
 // Expose all 'common' endpoints
-export * from 'common-ts/index.js'
+export * from 'common-ts/index'
 
+
+const DEBUG = true // log actions in console.debug
+
+const OFFLINE_POLLING_TIME = 5000 // ms
+
+/** Oracle Server State Holding */
+
+export interface OracleStateModel { // extends CommonStateModel possible?
+  version: string
+  publicKey: string
+  stakingAddress: string
+  oracleName: string
+}
+
+class OracleStateImpl /*extends CommonStateImpl*/ implements OracleStateModel {
+  version: string
+  publicKey: string
+  stakingAddress: string
+  oracleName: string
+}
+
+const state = new BehaviorSubject<OracleStateModel>(new OracleStateImpl())
+/** Exposed OracleState */
+export const OracleState = state.asObservable()
+/** Clear OracleTS OracleState */
+export function ClearOracleState() {
+  state.next(new OracleStateImpl())
+}
+
+type OracleServerAnnouncementMap = { [eventName: string]: OracleAnnouncement }
+
+// Announcement state
+const announcementNames: BehaviorSubject<string[]> = new BehaviorSubject<string[]>([])
+const announcements: BehaviorSubject<OracleServerAnnouncementMap> = new BehaviorSubject({})
+const flatAnnouncements: BehaviorSubject<OracleAnnouncement[]> = new BehaviorSubject<OracleAnnouncement[]>([])
+
+/** Exposed Announcement State */
+export const Announcements = flatAnnouncements.asObservable()
+/** Clear OracleTS Announcement State */
+export function ClearAnnouncementState() {
+  announcementNames.next([])
+  announcements.next({})
+  flatAnnouncements.next([])
+}
+
+function updateFlatAnnouncements() {
+  flatAnnouncements.next([...flatAnnouncements.value])
+}
+
+function addEventToState(a: OracleAnnouncement|null) {
+  if (a) {
+    announcements.value[a.eventName] = a
+    flatAnnouncements.value.push(a)
+  }
+}
+
+/** OracleTS Support Functions */
+
+/** Detect that backend is available and ready for interaction */
+export function WaitForServer() {
+  if (DEBUG) console.debug('WaitForServer()')
+  return from(<Promise<ServerResponse<VersionResponse>>>GetVersion()).pipe(
+    retryWhen(errors => {
+      return errors.pipe(
+        tap(_ => { if (DEBUG) console.debug('polling') }),
+        delayWhen(_ => timer(OFFLINE_POLLING_TIME)),
+      );
+    })
+  )
+}
+
+/** Load all data in OracleState and Announcement data */
+export function InitializeOracleState() {
+  return forkJoin([
+    getServerVersion(),
+    getPublicKey(),
+    getStakingAddress(),
+    getOracleName(),
+    GetAllAnnouncementsAndDetails(), // could require separate call to init
+  ]).pipe(tap(results => {
+    if (DEBUG) console.debug('InitializeOracleState()', results)
+  }))
+}
+
+/** Observable wrapped GetVersion() state fn */
+function getServerVersion() {
+  return from(<Promise<ServerResponse<VersionResponse>>>GetVersion()).pipe(tap(r => {
+    if (r.result) {
+      if (DEBUG) console.debug('getServerVersion()', r.result.version)
+      const s = state.getValue()
+      s.version = r.result.version
+      state.next(s)
+    }
+  }))
+}
+
+/** Observable wrapped GetPublicKey() state fn */
+function getPublicKey() {
+  return from(GetPublicKey()).pipe(tap(r => {
+    if (r.result) {
+      if (DEBUG) console.debug('getPublicKey()', r.result)
+      const s = state.getValue()
+      s.publicKey = r.result
+      state.next(s)
+    }
+  }))
+}
+
+/** Observable wrapped GetStakingAddress() state fn */
+function getStakingAddress() {
+  return from(GetStakingAddress()).pipe(tap(r => {
+    if (r.result) {
+      if (DEBUG) console.debug('getStakingAddress()', r.result)
+      const s = state.getValue()
+      s.stakingAddress = r.result
+      state.next(s)
+    }
+  }))
+}
+
+/** Observable wrapped GetOracleName() state fn */
+function getOracleName() {
+  return from(GetOracleName()).pipe(tap(r => {
+    if (r.result) {
+      if (DEBUG) console.debug('getOracleName()', r.result)
+      const s = state.getValue()
+      s.oracleName = r.result
+      state.next(s)
+    }
+  }))
+}
+
+/** Observable wrapped ListAnnouncements then getAllAnnouncementDetails() */
+export function GetAllAnnouncementsAndDetails(): Observable<OracleResponse<OracleEvent>[] | null> {
+  if (DEBUG) console.debug('GetAllAnnouncementsAndDetails()')
+  flatAnnouncements.next([])
+  const obs = from(ListAnnouncements())
+    .pipe(tap(r => {
+      if (r.result) {
+        announcementNames.next(<string[]>r.result)
+      }
+    }), switchMap(_ => getAllAnnouncementDetails()),
+    tap(r => {
+      if (r) {
+        for (const e of r) {
+          addEventToState(<OracleAnnouncement>e.result)
+        }
+        updateFlatAnnouncements()
+      }
+    })
+    // , switchMap(_ => getAnnouncementsFromOracleExplorer())
+    )
+  return obs
+}
+
+/** Observable wrapped GetAnnouncement for all announcementNames */
+function getAllAnnouncementDetails() {
+  if (DEBUG) console.debug('getAllAnnouncementDetails()')
+  if (announcementNames.value.length > 0) {
+    const obs = forkJoin(announcementNames.value.map(a => GetAnnouncement(a)))
+    obs.pipe(tap(r => {
+      if (r) {
+        for (const e of r) {
+          addEventToState(<OracleAnnouncement>e.result)
+        }
+        updateFlatAnnouncements()
+      }
+    }))
+    return obs
+  }
+  return of(null)
+}
+
+/** Reloads an Announcement after signing to update field values */
+export function ReloadAnnouncement(a: OracleAnnouncement) {
+  console.debug('ReloadAnnouncement()', a)
+  // Remove previous event state
+  const i = flatAnnouncements.value.findIndex(i => i.eventName === a.eventName)
+  if (i !== -1) {
+    flatAnnouncements.value.splice(i, 1)
+  }
+  let announcement: OracleAnnouncement|null = null
+  const obs = from(GetAnnouncement(a.eventName))
+    .pipe(tap(r => {
+      if (r.result) {
+        announcement = <OracleAnnouncement>r.result
+        addEventToState(announcement)
+        updateFlatAnnouncements()
+      }
+    })
+    , switchMap(_ => of(announcement))
+    )
+  return obs
+}
 
 /** Specific Oracle Server message functions */
 
-export function GetPublicKey() {
-  console.debug('GetPublicKey()')
+export function GetPublicKey(): Promise<OracleResponse<string>> {
+  if (DEBUG) console.debug('GetPublicKey()')
 
   const m = getMessageBody(MessageType.getpublickey)
   return SendServerMessage(m).then(response => {
@@ -20,8 +218,8 @@ export function GetPublicKey() {
   })
 }
 
-export function GetStakingAddress() {
-  console.debug('GetStakingAddress()')
+export function GetStakingAddress(): Promise<OracleResponse<string>> {
+  if (DEBUG) console.debug('GetStakingAddress()')
 
   const m = getMessageBody(MessageType.getstakingaddress)
   return SendServerMessage(m).then(response => {
@@ -29,8 +227,8 @@ export function GetStakingAddress() {
   })
 }
 
-export function ExportStakingAddressWIF() {
-  console.debug('ExportStakingAddressWIF()')
+export function ExportStakingAddressWIF(): Promise<OracleResponse<string>> {
+  if (DEBUG) console.debug('ExportStakingAddressWIF()')
 
   const m = getMessageBody(MessageType.exportstakingaddresswif)
   return SendServerMessage(m).then(response => {
@@ -38,8 +236,8 @@ export function ExportStakingAddressWIF() {
   })
 }
 
-export function ListAnnouncements() {
-  console.debug('ListAnnouncements()')
+export function ListAnnouncements(): Promise<OracleResponse<string[]>> {
+  if (DEBUG) console.debug('ListAnnouncements()')
 
   const m = getMessageBody(MessageType.listannouncements)
   return SendServerMessage(m).then(response => {
@@ -47,8 +245,8 @@ export function ListAnnouncements() {
   })
 }
 
-export function SignMessage(message: string) {
-  console.debug('SignMessage()', message)
+export function SignMessage(message: string): Promise<OracleResponse<string>> {
+  if (DEBUG) console.debug('SignMessage()', message)
   validateString(message, 'SignMessage()', 'message')
 
   const m = getMessageBody(MessageType.signmessage, [message])
@@ -57,8 +255,8 @@ export function SignMessage(message: string) {
   })
 }
 
-export function GetAnnouncement(eventName: string) {
-  console.debug('GetAnnouncement()', eventName)
+export function GetAnnouncement(eventName: string): Promise<OracleResponse<OracleEvent>> {
+  if (DEBUG) console.debug('GetAnnouncement()', eventName)
   validateString(eventName, 'GetAnnouncement()', 'eventName')
 
   const m = getMessageBody(MessageType.getannouncement, [eventName])
@@ -67,8 +265,9 @@ export function GetAnnouncement(eventName: string) {
   })
 }
  
-export function CreateEnumAnnouncement(eventName: string, maturationTimeISOString: string, outcomes: string[]) {
-  console.debug('CreateEnumAnnouncement()', eventName, maturationTimeISOString, outcomes)
+export function CreateEnumAnnouncement(eventName: string,
+    maturationTimeISOString: string, outcomes: string[]): Promise<OracleResponse<string>> {
+  if (DEBUG) console.debug('CreateEnumAnnouncement()', eventName, maturationTimeISOString, outcomes)
   validateString(eventName, 'CreateEnumAnnouncement()', 'eventName')
   validateISODateString(maturationTimeISOString, 'CreateEnumAnnouncement()', 'maturationTimeISOString')
   validateEnumOutcomes(outcomes, 'CreateEnumAnnouncement()')
@@ -79,8 +278,10 @@ export function CreateEnumAnnouncement(eventName: string, maturationTimeISOStrin
   })
 }
 
-export function CreateNumericAnnouncement(eventName: string, maturationTimeISOString: string, minValue: number, maxValue: number, unit: string, precision: number) {
-  console.debug('CreateNumericAnnouncement()', eventName, maturationTimeISOString, minValue, maxValue, unit, precision)
+export function CreateNumericAnnouncement(eventName: string, 
+    maturationTimeISOString: string, minValue: number, maxValue: number,
+    unit: string, precision: number): Promise<OracleResponse<string>> {
+  if (DEBUG) console.debug('CreateNumericAnnouncement()', eventName, maturationTimeISOString, minValue, maxValue, unit, precision)
   validateString(eventName, 'CreateNumericAnnouncement()', 'eventName')
   validateISODateString(maturationTimeISOString, 'CreateNumericAnnouncement()', 'maturationTimeISOString')
   validateNumber(minValue, 'CreateNumericAnnouncement()', 'minValue')
@@ -96,8 +297,8 @@ export function CreateNumericAnnouncement(eventName: string, maturationTimeISOSt
   })
 }
 
-export function SignEnum(eventName: string, outcome: string) {
-  console.debug('SignEnum()', eventName, outcome)
+export function SignEnum(eventName: string, outcome: string): Promise<OracleResponse<string>> {
+  if (DEBUG) console.debug('SignEnum()', eventName, outcome)
   validateString(eventName, 'SignEnum()', 'eventName')
   validateString(outcome, 'SignEnum()', 'outcome')
 
@@ -107,8 +308,8 @@ export function SignEnum(eventName: string, outcome: string) {
   })
 }
 
-export function SignDigits(eventName: string, outcome: number) {
-  console.debug('SignDigits()', eventName, outcome)
+export function SignDigits(eventName: string, outcome: number): Promise<OracleResponse<string>> {
+  if (DEBUG) console.debug('SignDigits()', eventName, outcome)
   validateString(eventName, 'SignDigits()', 'eventName')
   validateNumber(outcome, 'SignDigits()', 'outcome')
 
@@ -118,8 +319,8 @@ export function SignDigits(eventName: string, outcome: number) {
   })
 }
 
-export function GetSignatures(eventName: string) {
-  console.debug('GetSignatures()', eventName)
+export function GetSignatures(eventName: string): Promise<OracleResponse<OracleEvent>> {
+  if (DEBUG) console.debug('GetSignatures()', eventName)
   validateString(eventName, 'GetSignatures()', 'eventName')
 
   const m = getMessageBody(MessageType.getsignatures, [eventName])
@@ -128,8 +329,8 @@ export function GetSignatures(eventName: string) {
   })
 }
 
-export function DeleteAnnouncement(eventName: string) {
-  console.debug('DeleteAnnouncement()', eventName)
+export function DeleteAnnouncement(eventName: string): Promise<OracleResponse<OracleEvent>> {
+  if (DEBUG) console.debug('DeleteAnnouncement()', eventName)
   validateString(eventName, 'DeleteAnnouncement()', 'eventName')
 
   const m = getMessageBody(MessageType.deleteannouncement, [eventName])
@@ -138,8 +339,8 @@ export function DeleteAnnouncement(eventName: string) {
   })
 }
 
-export function DeleteAttestation(eventName: string) {
-  console.debug('DeleteAttestation()', eventName)
+export function DeleteAttestation(eventName: string): Promise<OracleResponse<OracleEvent>> {
+  if (DEBUG) console.debug('DeleteAttestation()', eventName)
   validateString(eventName, 'DeleteAttestation()', 'eventName')
 
   const m = getMessageBody(MessageType.deleteattestation, [eventName])
@@ -148,8 +349,8 @@ export function DeleteAttestation(eventName: string) {
   })
 }
 
-export function GetOracleName() {
-  console.debug('GetOracleName()')
+export function GetOracleName(): Promise<OracleResponse<string>> {
+  if (DEBUG) console.debug('GetOracleName()')
 
   const m = getMessageBody(MessageType.getoraclename)
   return SendServerMessage(m).then(response => {
@@ -157,8 +358,8 @@ export function GetOracleName() {
   })
 }
 
-export function SetOracleName(oracleName: string) {
-  console.debug('SetOracleName()', oracleName)
+export function SetOracleName(oracleName: string): Promise<OracleResponse<string>> {
+  if (DEBUG) console.debug('SetOracleName()', oracleName)
 
   const m = getMessageBody(MessageType.setoraclename, [oracleName])
   return SendServerMessage(m).then(response => {

--- a/oracle-server-ts/lib/type/oracle-server-types.ts
+++ b/oracle-server-ts/lib/type/oracle-server-types.ts
@@ -33,6 +33,26 @@ export const enum MessageType {
   // signevent = 'signevent',
 }
 
+// Serverside OracleAnnouncement response
+export interface OracleAnnouncement {
+  announcementSignature: string
+  announcementTLV: string
+  attestations: string
+  eventDescriptorTLV: string
+  eventName: string
+  eventTLV: string
+  maturationTime: string // "2030-01-03T00:30:00Z"
+  maturationTimeEpoch: number // 1893630600
+  nonces: string[]
+  outcomes: string[] // enum: ["value","value2"], numeric: [["number"]]
+  signedOutcome: string|null
+  signingVersion: string
+
+  // ids
+  announcementTLVsha256: string
+  eventDescriptorTLVsha256: string
+}
+
 // Serverside OracleEvent response
 export interface OracleEvent {
   announcementSignature: string

--- a/oracle-server-ts/package.json
+++ b/oracle-server-ts/package.json
@@ -34,7 +34,8 @@
     "tests": "node --loader ts-node/esm --es-module-specifier-resolution=node ./lib/tests.ts"
   },
   "dependencies": {
-    "common-ts": "file:../common-ts"
+    "common-ts": "file:../common-ts",
+    "rxjs": "~7.5.0"
   },
   "devDependencies": {
     "typescript": "^4.8.2"

--- a/oracle-server-ts/tsconfig.json
+++ b/oracle-server-ts/tsconfig.json
@@ -12,7 +12,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es6",                                     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ES2022",                                     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -25,7 +25,7 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    // "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "ES2022",                                /* Specify what module code is generated. */
     "rootDir": "lib",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
@@ -79,7 +79,7 @@
     // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    "strictPropertyInitialization": false,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
     // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */

--- a/oracle-server-ui/package.json
+++ b/oracle-server-ui/package.json
@@ -30,6 +30,7 @@
     "@ngx-translate/core": "^14.0.0",
     "@ngx-translate/http-loader": "^7.0.0",
     "file-saver": "^2.0.5",
+    "oracle-server-ts": "file:../oracle-server-ts",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.1",
     "zone.js": "~0.11.4"

--- a/oracle-server-ui/src/app/about/about.component.html
+++ b/oracle-server-ui/src/app/about/about.component.html
@@ -14,7 +14,7 @@
     <div class="version-container">
       <div class="version-section">
         <span class="label" translate>about.serverVersion</span>
-        <span class="server-version">{{ oracleState.serverVersion }}</span>
+        <span class="server-version">{{ oracleState.oracleState.version }}</span>
       </div>
       <div *ngIf="oracleState.buildConfig" class="version-section">
         <span class="label" translate>about.uiVersion</span>

--- a/oracle-server-ui/src/app/app.component.ts
+++ b/oracle-server-ui/src/app/app.component.ts
@@ -37,11 +37,10 @@ export class AppComponent implements OnInit, OnDestroy {
   loggedIn$: Subscription
   loggedOut$: Subscription
   subscriptions: Subscription[]
-  appServerReady$: Subscription
 
   constructor(private titleService: Title, private translate: TranslateService, public router: Router,
     public messageService: MessageService, private snackBar: MatSnackBar, public authService: AuthService,
-    private oracleStateService: OracleStateService, private overlay: OverlayContainer) {
+    private oracleService: OracleStateService, private overlay: OverlayContainer) {
     this.loggedIn$ = this.authService.loggedIn.subscribe(r => {
       console.debug('loggedIn')
       this.onLogin()
@@ -55,17 +54,14 @@ export class AppComponent implements OnInit, OnDestroy {
 
   private onLogin() {
     this.createSubscriptions()
-    this.appServerReady$ = this.oracleStateService.waitForAppServer().subscribe(r => {
-      console.debug(' waitForAppServer()', r)
-      this.appServerReady$.unsubscribe()
-      this.oracleStateService.initializeState()
-    })
+    // Initialize oracle server state
+    this.oracleService.initialize()
   }
 
   private createSubscriptions() {
     if (this.subscriptions) this.destroySubscriptions()
     this.subscriptions = []
-    let sub = this.oracleStateService.stateLoaded.subscribe(_ => {
+    let sub = this.oracleService.stateLoaded.subscribe(_ => {
       this.stateLoaded = true
       console.debug('stateLoaded:', this.router.url)
 
@@ -80,10 +76,9 @@ export class AppComponent implements OnInit, OnDestroy {
 
   private onLogout() {
     this.destroySubscriptions()
-    if (this.appServerReady$)
-      this.appServerReady$.unsubscribe()
     this.stateLoaded = false
     this.rightDrawer.close()
+    this.oracleService.uninitialize()
     this.router.navigate(['/login'], { queryParams: { loggedOut: 1 } })
   }
 

--- a/oracle-server-ui/src/app/configuration/configuration.component.ts
+++ b/oracle-server-ui/src/app/configuration/configuration.component.ts
@@ -59,7 +59,7 @@ export class ConfigurationComponent implements OnInit {
   // Refresh oracleExplorer / Blockstream data that may not have loaded over tor previously
   onRefreshOracleData() {
     console.debug('onRefreshOracleData()')
-    this.oracleExplorerService.getOracleName(this.oracleState.publicKey).subscribe()
+    this.oracleExplorerService.getOracleName(this.oracleState.oracleState.publicKey).subscribe()
     this.oracleState.getStakingBalance().subscribe()
   }
 

--- a/oracle-server-ui/src/app/oracle/oracle.component.html
+++ b/oracle-server-ui/src/app/oracle/oracle.component.html
@@ -23,13 +23,24 @@
           </mat-form-field>
           <mat-form-field>
             <mat-label translate>oracle.publicKey</mat-label>
-            <input matInput name="publicKey" type="text"
-              [(ngModel)]="oracleState.publicKey" readonly="true">
+            <input class="public-key-input" matInput name="publicKey" type="text"
+              [(ngModel)]="oracleState.oracleState.publicKey" readonly="true">
+            <button mat-icon-button matSuffix
+              matTooltip="{{ 'action.copyToClipboard' | translate }}"
+              (click)="copyToClipboard(oracleState.oracleState.publicKey)">
+              <mat-icon>content_copy</mat-icon>
+            </button>
           </mat-form-field>
+          <!-- Confusing Users -->
           <mat-form-field>
             <mat-label translate>oracle.stakingAddress</mat-label>
-            <input matInput name="stakingAddress" type="text"
-              [(ngModel)]="oracleState.stakingAddress" readonly="true">
+            <input class="staking-address-input" matInput name="stakingAddress" type="text"
+              [(ngModel)]="oracleState.oracleState.stakingAddress" readonly="true">
+            <button mat-icon-button matSuffix
+              matTooltip="{{ 'action.copyToClipboard' | translate }}"
+              (click)="copyToClipboard(oracleState.oracleState.stakingAddress)">
+              <mat-icon>content_copy</mat-icon>
+            </button>
           </mat-form-field>
           <mat-form-field>
             <mat-label translate>oracle.stakedAmount</mat-label>
@@ -102,7 +113,7 @@
             <td mat-cell *matCellDef="let announcement">
               <div *ngIf="announcement.signedOutcome !== null" class="signedOutcome-container">
                 <span class="outcome-label">{{ announcement.signedOutcome }}</span>
-    
+
                 <ng-container *ngIf="oracleName && oracleState.oeAnnouncements.value[announcement.eventName] === undefined">
                   <mat-spinner class="spinner" diameter="20"></mat-spinner>
                 </ng-container>

--- a/oracle-server-ui/src/app/oracle/oracle.component.scss
+++ b/oracle-server-ui/src/app/oracle/oracle.component.scss
@@ -33,14 +33,16 @@
     }
 
     .oracle-form {
-      flex: 1;
-      max-width: 600px;
-      
       display: flex;
       flex-direction: column;
       justify-content: center;
 
       margin: 1rem 1rem 0 1rem;
+
+      .public-key-input,
+      .staking-address-input {
+        text-overflow: ellipsis;
+      }
     }
   }
 

--- a/oracle-server-ui/src/app/oracle/oracle.component.ts
+++ b/oracle-server-ui/src/app/oracle/oracle.component.ts
@@ -17,7 +17,7 @@ import { OracleStateService } from '~service/oracle-state.service'
 import { OracleAnnouncement } from '~type/oracle-server-types'
 
 import { formatOutcomes } from '~util/oracle-server-util'
-import { KrystalBullImages } from '~util/ui-util'
+import { copyToClipboard, KrystalBullImages } from '~util/ui-util'
 
 
 @Component({
@@ -28,6 +28,7 @@ import { KrystalBullImages } from '~util/ui-util'
 export class OracleComponent implements OnInit, AfterViewInit {
 
   public KrystalBullImages = KrystalBullImages
+  public copyToClipboard = copyToClipboard
   public formatOutcomes = formatOutcomes
 
   @ViewChild('leftDrawer') leftDrawer: MatDrawer
@@ -70,14 +71,15 @@ export class OracleComponent implements OnInit, AfterViewInit {
     this.oracleExplorerService.serverOracleName.subscribe(serverSet => {
       this.oracleNameReadOnly = serverSet
     })
-    this.onRefreshAnnouncements()
+    // Used to trigger announcement loading here, now using OracleTS auto-loading
+    // this.onRefreshAnnouncements()
   }
 
   ngAfterViewInit() {
     this.dataSource.sort = this.sort;
 
-    this.oracleState.flatAnnouncements.subscribe(_ => {
-      this.dataSource.data = this.oracleState.flatAnnouncements.value
+    this.oracleState.OracleTS.Announcements.subscribe(a => {
+      this.dataSource.data = a
       this.table.renderRows()
     })
   }

--- a/oracle-server-ui/src/assets/i18n/en.json
+++ b/oracle-server-ui/src/assets/i18n/en.json
@@ -271,7 +271,8 @@
     "logout": "Logout",
     "stay": "Stay",
     "add": "Add",
-    "remove": "Remove"
+    "remove": "Remove",
+    "copyToClipboard": "Copy to Clipboard"
   }
 
 }

--- a/oracle-server-ui/src/service/oracle-state.service.ts
+++ b/oracle-server-ui/src/service/oracle-state.service.ts
@@ -1,6 +1,11 @@
-import { EventEmitter, Injectable, OnInit } from '@angular/core'
-import { BehaviorSubject, forkJoin, of, timer } from 'rxjs'
-import { delayWhen, retryWhen, switchMap, tap } from 'rxjs/operators'
+import { EventEmitter, Injectable } from '@angular/core'
+import { BehaviorSubject, forkJoin, of } from 'rxjs'
+import { switchMap, tap } from 'rxjs/operators'
+
+import * as OracleTS from 'oracle-server-ts/index'
+import { OracleStateModel } from 'oracle-server-ts/index'
+
+import { environment } from '~environments'
 
 import { BuildConfig } from '~type/proxy-server-types'
 import { MessageType, OracleAnnouncement } from '~type/oracle-server-types'
@@ -8,39 +13,41 @@ import { OracleAnnouncementsResponse } from '~type/oracle-explorer-types'
 
 import { getMessageBody } from '~util/oracle-server-util'
 
+import { AuthService } from './auth.service'
 import { BlockstreamService } from './blockstream-service'
 import { MempoolService } from './mempool-service'
 import { MessageService } from './message.service'
 import { OracleExplorerService } from './oracle-explorer.service'
 
 
-const OFFLINE_POLLING_TIME = 5000 // ms
-
-type OracleServerAnnouncementMap = { [eventName: string]: OracleAnnouncement }
 type OracleExplorerAnnouncementMap = { [eventName: string]: OracleAnnouncementsResponse }
 
 @Injectable({ providedIn: 'root' })
 export class OracleStateService {
 
-  serverVersion = ''
+  /** OracleTS data pass through */
+  // get commonState() { return OracleTS.CommonState }
+  get OracleTS() { return OracleTS } // Common library exposure point
+  private _oracleState: OracleStateModel
+  get oracleState() { return this._oracleState }
+  private _announcements: OracleAnnouncement[]
+  get announcements() { return this._announcements }
+
+  /** Pass through OracleTS functions */
+  getAllAnnouncements() { return OracleTS.GetAllAnnouncementsAndDetails() }
+  reloadAnnouncement(announcement: OracleAnnouncement) {
+    let announce: OracleAnnouncement|null = null
+    return OracleTS.ReloadAnnouncement(announcement).pipe(switchMap(a => {
+      announce = a
+      if (a) return this.getOEAnnouncement(a)
+      else return of(null)
+    }), switchMap(_ => of(announce)))
+  }
+
+  /** Proxy server build data */
   buildConfig: BuildConfig
 
-  // oracleName = '' // lives on OracleExpolorer service for now
-  publicKey = ''
-  stakingAddress = ''
   stakedAmount = ''
-
-  // Server state
-  announcementNames: BehaviorSubject<string[]> = new BehaviorSubject<string[]>([])
-  announcements: BehaviorSubject<OracleServerAnnouncementMap> = new BehaviorSubject({})
-  flatAnnouncements: BehaviorSubject<OracleAnnouncement[]> = new BehaviorSubject<OracleAnnouncement[]>([])
-
-  private addEventToState(a: OracleAnnouncement|null) {
-    if (a) {
-      this.announcements.value[a.eventName] = a
-      this.flatAnnouncements.value.push(a)
-    }
-  }
 
   // Oracle Explorer state
   oeAnnouncements: BehaviorSubject<OracleExplorerAnnouncementMap> = new BehaviorSubject({}) // should this index on sha256 id instead?
@@ -48,54 +55,54 @@ export class OracleStateService {
   // Initial State Loaded signal
   stateLoaded: EventEmitter<void> = new EventEmitter()
 
-  private updateFlatAnnouncements() {
-    this.flatAnnouncements.next([...this.flatAnnouncements.value])
-  }
-
   private updateAnnouncements() {
     this.oeAnnouncements.next(Object.assign({}, this.oeAnnouncements.value))
   }
 
-  constructor(private messageService: MessageService, private oracleExplorerService: OracleExplorerService, 
+  constructor(private authService: AuthService, private messageService: MessageService, private oracleExplorerService: OracleExplorerService, 
     private blockstreamService: BlockstreamService, private mempoolService: MempoolService) {
     
+      OracleTS.OracleState.subscribe(os => {
+        this._oracleState = os
+      })
+      OracleTS.Announcements.subscribe(as => {
+        this._announcements = as
+      })
   }
 
-  // Detect that backend is available and ready for interaction
-  public waitForAppServer() {
-    console.debug('waitForAppServer()')
-    return this.getServerVersion().pipe(
-      retryWhen(errors => {
-        return errors.pipe(
-          tap(_ => console.debug('polling oracleServer')),
-          delayWhen(_ => timer(OFFLINE_POLLING_TIME)),
-        );
-      }),
-      tap(_ => {})
-    )
+  /** Configure OracleTS, wait for backend server, and load state */
+  initialize() {
+    console.debug('initialize()')
+    // Communicate with OracleTS via proxy server
+    OracleTS.ConfigureServerURL(environment.oracleServerApi)
+    const token = this.authService.getToken()
+    if (token) {
+      OracleTS.ConfigureAuthorizationHeader('Bearer ' + token)
+    }
+    return OracleTS.WaitForServer().subscribe(r => {
+      OracleTS.InitializeOracleState().subscribe(r => {
+        this.initializeState()
+      })
+    })
   }
 
+  uninitialize() {
+    console.debug('uninitialize()')
+    OracleTS.ClearOracleState()
+    OracleTS.ClearAnnouncementState()
+  }
+
+  /** Load anything locally that needs to follow OracleTS loading */
   initializeState() {
     console.debug('initializeState()')
-
     return forkJoin([
-      this.getServerVersion(),
-      // this.getBuildConfig(),
-      this.getPublicKeyAndOracleName(),
-      this.getStakingAddressAndBalance(),
-      // this.getAllAnnouncements(), // pulling in oracle component
+      this.getOracleName(),
+      this.getStakingBalance(),
+      this.getAnnouncementsFromOracleExplorer(),
     ]).subscribe(_ => {
       console.debug(' initializedState() initialized')
       this.stateLoaded.next()
     })
-  }
-
-  private getServerVersion() {
-    return this.messageService.getServerVersion().pipe(tap(r => {
-      if (r.result) {
-        this.serverVersion = r.result.version;
-      }
-    }))
   }
 
   private getBuildConfig() {
@@ -114,33 +121,19 @@ export class OracleStateService {
     ])
   }
 
-  private getPublicKeyAndOracleName() {
-    console.debug('getPublicKeyAndOracleName()')
-    return this.messageService.sendMessage(getMessageBody(MessageType.getpublickey)).pipe(tap(r => {
-      if (r.result) {
-        this.publicKey = r.result
-      }
-    }), switchMap(_ => {
-      if (!this.oracleExplorerService.oracleName.value)
-        return this.oracleExplorerService.getLocalOracleName(this.publicKey)
-      else return of(null)
-    }))
-  }
-
-  private getStakingAddressAndBalance() {
-    console.debug('getStakingAddressAndBalance()')
-    return this.messageService.sendMessage(getMessageBody(MessageType.getstakingaddress)).pipe(tap(r => {
-      if (r.result) {
-        this.stakingAddress = r.result
-      }
-    }), switchMap(_ => this.getStakingBalance()))
+  private getOracleName() {
+    console.debug('getOracleName()')
+    if (this.oracleState.publicKey && !this.oracleExplorerService.oracleName.value)
+      return this.oracleExplorerService.getLocalOracleName(this.oracleState.publicKey)
+    else return of(null)
   }
 
   getStakingBalance() {
-    console.debug('getStakingBalance()')
-    if (this.stakingAddress) {
-      return this.mempoolService.getBalance(this.stakingAddress).pipe(tap(r => {
+    console.debug('getStakingBalance()', this.oracleState.stakingAddress)
+    if (this.oracleState.stakingAddress) {
+      return this.mempoolService.getBalance(this.oracleState.stakingAddress).pipe(tap(r => {
         this.stakedAmount = this.blockstreamService.balanceFromGetBalance(r).toString()
+        console.debug('stakedAmount:', this.stakedAmount)
       }))
     }
     return of(null)
@@ -153,72 +146,12 @@ export class OracleStateService {
     }))
   }
 
-  getAllAnnouncements() {
-    console.debug('getAllAnnouncements()')
-    this.flatAnnouncements.next([])
-    const obs = this.messageService.sendMessage(getMessageBody(MessageType.listannouncements))
-      .pipe(tap(r => {
-        if (r.result) {
-          this.announcementNames.next(<string[]>r.result)
-        }
-      }), switchMap(_ => this.getAllAnnouncementDetails()),
-      tap(r => {
-        if (r) {
-          for (const e of r) {
-            this.addEventToState(<OracleAnnouncement>e.result)
-          }
-          this.updateFlatAnnouncements()
-        }
-      }), switchMap(_ => this.getAnnouncementsFromOracleExplorer()))
-    return obs
-  }
-
-  private getAllAnnouncementDetails() {
-    console.debug('getAllAnnouncementDetails()')
-    if (this.announcementNames.value.length > 0) {
-      const obs = forkJoin(this.announcementNames.value.map(a => this.messageService.sendMessage(getMessageBody(MessageType.getannouncement, [a]))))
-      obs.pipe(tap(r => {
-        if (r) {
-          for (const e of r) {
-            this.addEventToState(<OracleAnnouncement>e.result)
-          }
-          this.updateFlatAnnouncements()
-        }
-      }))
-      return obs
-    }
-    return of(null)
-  }
-
-  // Reloads an Announcement after signing to update field values
-  reloadAnnouncement(a: OracleAnnouncement) {
-    console.debug('reloadAnnouncement()', a)
-    // Remove previous event state
-    const i = this.flatAnnouncements.value.findIndex(i => i.eventName === a.eventName)
-    if (i !== -1) {
-      this.flatAnnouncements.value.splice(i, 1)
-    }
-    let announcement: OracleAnnouncement|null = null
-    const obs = this.messageService.sendMessage(getMessageBody(MessageType.getannouncement, [a.eventName]))
-      .pipe(tap(r => {
-        if (r.result) {
-          announcement = r.result
-          this.addEventToState(announcement)
-          this.updateFlatAnnouncements()
-        }
-      }), switchMap(_ => {
-        if (announcement) return this.getOEAnnouncement(announcement)
-        else return of(null)
-      }), switchMap(_ => of(announcement)))
-    return obs
-  }
-
   private getAnnouncementsFromOracleExplorer() {
-    console.debug('getAnnouncementsFromOracleExplorer()', this.flatAnnouncements.value)
+    console.debug('getAnnouncementsFromOracleExplorer()', this.announcements)
     this.oeAnnouncements.next({})
-    if (this.flatAnnouncements.value.length > 0) {
+    if (this.announcements.length > 0) {
       // Have seen these 403 against the Production Oracle Server over Tor
-      const obs = forkJoin(this.flatAnnouncements.value.map(e => this.oeAnnouncements.value[e.eventName] ? 
+      const obs = forkJoin(this.announcements.map(e => this.oeAnnouncements.value[e.eventName] ? 
         of(this.oeAnnouncements.value[e.eventName]) : this.getOEAnnouncement(e)))
       return obs
     }
@@ -227,7 +160,7 @@ export class OracleStateService {
 
   // Check if the event is published to the oracle explorer
   getOEAnnouncement(a: OracleAnnouncement) {
-    console.debug('getOEAnnouncement()', a)
+    // console.debug('getOEAnnouncement()', a.announcementTLVsha256)
     const obs = this.oracleExplorerService.getAnnouncement(a.announcementTLVsha256)
       .pipe(tap(r => {
         console.debug('getOEAnnouncement()', a.announcementTLVsha256, r)

--- a/oracle-server-ui/src/type/oracle-server-types.ts
+++ b/oracle-server-ui/src/type/oracle-server-types.ts
@@ -51,6 +51,26 @@ export interface OracleAnnouncement {
   eventDescriptorTLVsha256: string
 }
 
+// Serverside OracleEvent response
+export interface OracleEvent {
+  announcementSignature: string
+  announcementTLV: string
+  attestations: string
+  eventDescriptorTLV: string
+  eventName: string
+  eventTLV: string
+  maturationTime: string // "2030-01-03T00:30:00Z"
+  maturationTimeEpoch: number // 1893630600
+  nonces: string[]
+  outcomes: string[]|string[][] // enum, numeric: [["number"]]
+  signedOutcome: string
+  signingVersion: string
+
+  // ids
+  announcementTLVsha256: string
+  eventDescriptorTLVsha256: string
+}
+
 // Serverside message response
 export interface OracleResponse<T> {
   result: T|null // Can also be a complex type like getevent response

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitcoin-s-ts",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitcoin-s-ts",
-      "version": "1.9.4",
+      "version": "1.9.5",
       "workspaces": [
         "common-ts",
         "wallet-ts",
@@ -18,14 +18,12 @@
       ]
     },
     "common-ts": {
-      "version": "1.9.4",
+      "version": "1.9.5",
       "dependencies": {
-        "express": "^4.17.1",
-        "needle": "^3.0.0"
+        "express": "^4.17.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
-        "@types/needle": "^2.5.2",
         "typescript": "^4.8.2"
       }
     },
@@ -3110,15 +3108,6 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
       "devOptional": true
-    },
-    "node_modules/@types/needle": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@types/needle/-/needle-2.5.3.tgz",
-      "integrity": "sha512-RwgTwMRaedfyCBe5SSWMpm1Yqzc5UPZEMw0eAd09OSyV93nLRj9/evMGZmgFeHKzUOd4xxtHvgtc+rjcBjI1Qg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "16.11.59",
@@ -8441,6 +8430,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/needle/-/needle-3.1.0.tgz",
       "integrity": "sha512-gCE9weDhjVGCRqS8dwDR/D3GTAeyXLXuqp7I8EzH6DllZGXSUyxuqqLh+YX9rMAWaaTFyVAg6rHGL25dqvczKw==",
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.6.3",
@@ -8457,6 +8448,8 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -8465,6 +8458,8 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -9137,6 +9132,10 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/oracle-server-ts": {
+      "resolved": "oracle-server-ts",
+      "link": true
     },
     "node_modules/oracle-server-ui": {
       "resolved": "oracle-server-ui",
@@ -10890,7 +10889,8 @@
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "node_modules/schema-utils": {
       "version": "2.7.1",
@@ -12384,6 +12384,10 @@
       "resolved": "wallet-server-ui-proxy",
       "link": true
     },
+    "node_modules/wallet-ts": {
+      "resolved": "wallet-ts",
+      "link": true
+    },
     "node_modules/watchpack": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -13000,16 +13004,18 @@
       }
     },
     "oracle-server-ts": {
-      "version": "1.9.4",
+      "name": "@bitcoin-s-ts/oracle-server-ts",
+      "version": "1.9.5",
       "dependencies": {
-        "common-ts": "file:../common-ts"
+        "common-ts": "file:../common-ts",
+        "rxjs": "~7.5.0"
       },
       "devDependencies": {
         "typescript": "^4.8.2"
       }
     },
     "oracle-server-ui": {
-      "version": "1.9.4",
+      "version": "1.9.5",
       "dependencies": {
         "@angular/animations": "^14.2.0",
         "@angular/cdk": "^14.2.0",
@@ -13024,6 +13030,7 @@
         "@ngx-translate/core": "^14.0.0",
         "@ngx-translate/http-loader": "^7.0.0",
         "file-saver": "^2.0.5",
+        "oracle-server-ts": "file:../oracle-server-ts",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.1",
         "zone.js": "~0.11.4"
@@ -13045,7 +13052,7 @@
       }
     },
     "oracle-server-ui-proxy": {
-      "version": "1.9.4",
+      "version": "1.9.5",
       "license": "MIT",
       "dependencies": {
         "@bitcoin-s-ts/oracle-server-ts": "file:../oracle-server-ts",
@@ -13072,7 +13079,7 @@
       }
     },
     "wallet-server-ui": {
-      "version": "1.9.4",
+      "version": "1.9.5",
       "dependencies": {
         "@angular/animations": "^14.2.0",
         "@angular/cdk": "^14.2.0",
@@ -13098,6 +13105,7 @@
         "ngx-lottie": "^9.0.1",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.1",
+        "wallet-ts": "file:../wallet-ts",
         "zone.js": "~0.11.4"
       },
       "devDependencies": {
@@ -13106,7 +13114,6 @@
         "@angular/compiler-cli": "^14.2.0",
         "@types/file-saver": "^2.0.4",
         "@types/jasmine": "~3.8.0",
-        "@types/node": "^16.11.56",
         "jasmine-core": "~3.8.0",
         "karma": "~6.3.0",
         "karma-chrome-launcher": "~3.1.0",
@@ -13117,7 +13124,7 @@
       }
     },
     "wallet-server-ui-proxy": {
-      "version": "1.9.4",
+      "version": "1.9.5",
       "dependencies": {
         "@bitcoin-s-ts/wallet-ts": "file:../wallet-ts",
         "common-ts": "file:../common-ts",
@@ -13143,7 +13150,8 @@
       }
     },
     "wallet-ts": {
-      "version": "1.9.4",
+      "name": "@bitcoin-s-ts/wallet-ts",
+      "version": "1.9.5",
       "dependencies": {
         "common-ts": "file:../common-ts"
       },
@@ -14689,6 +14697,7 @@
       "version": "file:oracle-server-ts",
       "requires": {
         "common-ts": "file:../common-ts",
+        "rxjs": "~7.5.0",
         "typescript": "^4.8.2"
       }
     },
@@ -15313,15 +15322,6 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
       "devOptional": true
-    },
-    "@types/needle": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@types/needle/-/needle-2.5.3.tgz",
-      "integrity": "sha512-RwgTwMRaedfyCBe5SSWMpm1Yqzc5UPZEMw0eAd09OSyV93nLRj9/evMGZmgFeHKzUOd4xxtHvgtc+rjcBjI1Qg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/node": {
       "version": "16.11.59",
@@ -16332,9 +16332,7 @@
       "version": "file:common-ts",
       "requires": {
         "@types/express": "^4.17.13",
-        "@types/needle": "^2.5.2",
         "express": "^4.17.1",
-        "needle": "^3.0.0",
         "typescript": "^4.8.2"
       }
     },
@@ -19296,6 +19294,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/needle/-/needle-3.1.0.tgz",
       "integrity": "sha512-gCE9weDhjVGCRqS8dwDR/D3GTAeyXLXuqp7I8EzH6DllZGXSUyxuqqLh+YX9rMAWaaTFyVAg6rHGL25dqvczKw==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.6.3",
@@ -19306,6 +19306,8 @@
           "version": "3.2.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -19314,6 +19316,8 @@
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -19820,6 +19824,14 @@
         }
       }
     },
+    "oracle-server-ts": {
+      "version": "file:oracle-server-ts",
+      "requires": {
+        "common-ts": "file:../common-ts",
+        "rxjs": "~7.5.0",
+        "typescript": "^4.8.2"
+      }
+    },
     "oracle-server-ui": {
       "version": "file:oracle-server-ui",
       "requires": {
@@ -19848,6 +19860,7 @@
         "karma-coverage": "~2.0.3",
         "karma-jasmine": "~4.0.0",
         "karma-jasmine-html-reporter": "~1.7.0",
+        "oracle-server-ts": "file:../oracle-server-ts",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.1",
         "typescript": "~4.8.2",
@@ -21066,7 +21079,8 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "schema-utils": {
       "version": "2.7.1",
@@ -22198,7 +22212,6 @@
         "@ngx-translate/http-loader": "^7.0.0",
         "@types/file-saver": "^2.0.4",
         "@types/jasmine": "~3.8.0",
-        "@types/node": "^16.11.56",
         "@zxing/browser": "^0.1.1",
         "@zxing/library": "^0.19.1",
         "@zxing/ngx-scanner": "~3.6.2",
@@ -22218,6 +22231,7 @@
         "rxjs": "~7.5.0",
         "tslib": "^2.3.1",
         "typescript": "~4.8.2",
+        "wallet-ts": "file:../wallet-ts",
         "zone.js": "~0.11.4"
       }
     },
@@ -22243,6 +22257,13 @@
         "webpack-cli": "^4.9.2",
         "webpack-node-externals": "^3.0.0",
         "winston": "^3.3.3"
+      }
+    },
+    "wallet-ts": {
+      "version": "file:wallet-ts",
+      "requires": {
+        "common-ts": "file:../common-ts",
+        "typescript": "^4.8.2"
       }
     },
     "watchpack": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,9 +7,9 @@
     "declarationMap": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "module": "ES2020",
+    "module": "ES2022",
     "lib": [
-      "ES2018"
+      "ES2022"
     ],
     "sourceMap": true,
     "downlevelIteration": true,


### PR DESCRIPTION
This moves the startup polling loop and state initialization for the oracleServer to the oracle-server-ts library and binds those values at the UI. "Any Javascript UI" should be able to use the oracle-server-ts to bind through a backend proxy and interact with the oracleServer.

Added copy to clipboard buttons on top level UI fields for public key and bitcoin staking address.

![Screen Shot 2022-10-03 at 1 34 49 PM](https://user-images.githubusercontent.com/22351459/193663423-41dc30cd-c264-4d2f-923f-9b0ca5045dd0.png)
